### PR TITLE
Align backend trading calendar handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ poetry install
 
 `poetry install` pulls `market-data-library` from Git over SSH, so the machine must have access to `git@github.com:hanchiang/market_data_api.git`.
 Use the sibling workspace override only when backend validation must exercise unpublished local `market-data-library` changes.
+The override script installs the sibling repo as an editable package in the backend Poetry environment, so rerun it after `poetry install` if Poetry restores the git dependency.
 
 Switch to the sibling workspace copy of `market-data-library` when needed:
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -611,6 +611,26 @@ files = [
 ]
 
 [[package]]
+name = "exchange-calendars"
+version = "4.13.2"
+description = "Calendars for securities exchanges"
+optional = false
+python-versions = "<4,>=3.10"
+groups = ["main"]
+files = [
+    {file = "exchange_calendars-4.13.2-py3-none-any.whl", hash = "sha256:fc5a2ad0d61b5c3a6539a3061cd4cbb55c59f4a903455cec7926e4b798919996"},
+    {file = "exchange_calendars-4.13.2.tar.gz", hash = "sha256:a9459425dd64142cd54fbc639847403c7e0c33d60fbc326c94fc1d6bd127f002"},
+]
+
+[package.dependencies]
+korean_lunar_calendar = ">=0.3.1"
+numpy = ">=1.26.4"
+pandas = ">=1.5.0"
+pyluach = ">=2.3.0"
+toolz = ">=1.0.0"
+tzdata = ">=2025.2"
+
+[[package]]
 name = "fastapi"
 version = "0.88.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -885,6 +905,18 @@ files = [
 ]
 
 [[package]]
+name = "korean-lunar-calendar"
+version = "0.3.1"
+description = "Korean Lunar Calendar"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "korean_lunar_calendar-0.3.1-py3-none-any.whl", hash = "sha256:392757135c492c4f42a604e6038042953c35c6f449dda5f27e3f86a7f9c943e5"},
+    {file = "korean_lunar_calendar-0.3.1.tar.gz", hash = "sha256:eb2c485124a061016926bdea6d89efdf9b9fdbf16db55895b6cf1e5bec17b857"},
+]
+
+[[package]]
 name = "market-data-library"
 version = "0.1.0"
 description = ""
@@ -1139,6 +1171,88 @@ files = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.4"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.11"
+groups = ["main"]
+files = [
+    {file = "numpy-2.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f983334aea213c99992053ede6168500e5f086ce74fbc4acc3f2b00f5762e9db"},
+    {file = "numpy-2.4.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:72944b19f2324114e9dc86a159787333b77874143efcf89a5167ef83cfee8af0"},
+    {file = "numpy-2.4.4-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:86b6f55f5a352b48d7fbfd2dbc3d5b780b2d79f4d3c121f33eb6efb22e9a2015"},
+    {file = "numpy-2.4.4-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:ba1f4fc670ed79f876f70082eff4f9583c15fb9a4b89d6188412de4d18ae2f40"},
+    {file = "numpy-2.4.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a87ec22c87be071b6bdbd27920b129b94f2fc964358ce38f3822635a3e2e03d"},
+    {file = "numpy-2.4.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df3775294accfdd75f32c74ae39fcba920c9a378a2fc18a12b6820aa8c1fb502"},
+    {file = "numpy-2.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0d4e437e295f18ec29bc79daf55e8a47a9113df44d66f702f02a293d93a2d6dd"},
+    {file = "numpy-2.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6aa3236c78803afbcb255045fbef97a9e25a1f6c9888357d205ddc42f4d6eba5"},
+    {file = "numpy-2.4.4-cp311-cp311-win32.whl", hash = "sha256:30caa73029a225b2d40d9fae193e008e24b2026b7ee1a867b7ee8d96ca1a448e"},
+    {file = "numpy-2.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:6bbe4eb67390b0a0265a2c25458f6b90a409d5d069f1041e6aff1e27e3d9a79e"},
+    {file = "numpy-2.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:fcfe2045fd2e8f3cb0ce9d4ba6dba6333b8fa05bb8a4939c908cd43322d14c7e"},
+    {file = "numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b"},
+    {file = "numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e"},
+    {file = "numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842"},
+    {file = "numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8"},
+    {file = "numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121"},
+    {file = "numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e"},
+    {file = "numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44"},
+    {file = "numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d"},
+    {file = "numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827"},
+    {file = "numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a"},
+    {file = "numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec"},
+    {file = "numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50"},
+    {file = "numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115"},
+    {file = "numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af"},
+    {file = "numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c"},
+    {file = "numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103"},
+    {file = "numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83"},
+    {file = "numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed"},
+    {file = "numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959"},
+    {file = "numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed"},
+    {file = "numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf"},
+    {file = "numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d"},
+    {file = "numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5"},
+    {file = "numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7"},
+    {file = "numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93"},
+    {file = "numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e"},
+    {file = "numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40"},
+    {file = "numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e"},
+    {file = "numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392"},
+    {file = "numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008"},
+    {file = "numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8"},
+    {file = "numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233"},
+    {file = "numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0"},
+    {file = "numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a"},
+    {file = "numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a"},
+    {file = "numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b"},
+    {file = "numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a"},
+    {file = "numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d"},
+    {file = "numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252"},
+    {file = "numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f"},
+    {file = "numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc"},
+    {file = "numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74"},
+    {file = "numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb"},
+    {file = "numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e"},
+    {file = "numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113"},
+    {file = "numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d"},
+    {file = "numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d"},
+    {file = "numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f"},
+    {file = "numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0"},
+    {file = "numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150"},
+    {file = "numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871"},
+    {file = "numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e"},
+    {file = "numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7"},
+    {file = "numpy-2.4.4-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:58c8b5929fcb8287cbd6f0a3fae19c6e03a5c48402ae792962ac465224a629a4"},
+    {file = "numpy-2.4.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:eea7ac5d2dce4189771cedb559c738a71512768210dc4e4753b107a2048b3d0e"},
+    {file = "numpy-2.4.4-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:51fc224f7ca4d92656d5a5eb315f12eb5fe2c97a66249aa7b5f562528a3be38c"},
+    {file = "numpy-2.4.4-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:28a650663f7314afc3e6ec620f44f333c386aad9f6fc472030865dc0ebb26ee3"},
+    {file = "numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19710a9ca9992d7174e9c52f643d4272dcd1558c5f7af7f6f8190f633bd651a7"},
+    {file = "numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b2aec6af35c113b05695ebb5749a787acd63cafc83086a05771d1e1cd1e555f"},
+    {file = "numpy-2.4.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f2cf083b324a467e1ab358c105f6cad5ea950f50524668a80c486ff1db24e119"},
+    {file = "numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0"},
+]
+
+[[package]]
 name = "outcome"
 version = "1.3.0.post0"
 description = "Capture the outcome of Python function calls."
@@ -1164,6 +1278,95 @@ files = [
     {file = "packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"},
     {file = "packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4"},
 ]
+
+[[package]]
+name = "pandas"
+version = "3.0.2"
+description = "Powerful data structures for data analysis, time series, and statistics"
+optional = false
+python-versions = ">=3.11"
+groups = ["main"]
+files = [
+    {file = "pandas-3.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a727a73cbdba2f7458dc82449e2315899d5140b449015d822f515749a46cbbe0"},
+    {file = "pandas-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dbbd4aa20ca51e63b53bbde6a0fa4254b1aaabb74d2f542df7a7959feb1d760c"},
+    {file = "pandas-3.0.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:339dda302bd8369dedeae979cb750e484d549b563c3f54f3922cb8ff4978c5eb"},
+    {file = "pandas-3.0.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:61c2fd96d72b983a9891b2598f286befd4ad262161a609c92dc1652544b46b76"},
+    {file = "pandas-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c934008c733b8bbea273ea308b73b3156f0181e5b72960790b09c18a2794fe1e"},
+    {file = "pandas-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:60a80bb4feacbef5e1447a3f82c33209c8b7e07f28d805cfd1fb951e5cb443aa"},
+    {file = "pandas-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:ed72cb3f45190874eb579c64fa92d9df74e98fd63e2be7f62bce5ace0ade61df"},
+    {file = "pandas-3.0.2-cp311-cp311-win_arm64.whl", hash = "sha256:f12b1a9e332c01e09510586f8ca9b108fd631fd656af82e452d7315ef6df5f9f"},
+    {file = "pandas-3.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:232a70ebb568c0c4d2db4584f338c1577d81e3af63292208d615907b698a0f18"},
+    {file = "pandas-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:970762605cff1ca0d3f71ed4f3a769ea8f85fc8e6348f6e110b8fea7e6eb5a14"},
+    {file = "pandas-3.0.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aff4e6f4d722e0652707d7bcb190c445fe58428500c6d16005b02401764b1b3d"},
+    {file = "pandas-3.0.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef8b27695c3d3dc78403c9a7d5e59a62d5464a7e1123b4e0042763f7104dc74f"},
+    {file = "pandas-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f8d68083e49e16b84734eb1a4dcae4259a75c90fb6e2251ab9a00b61120c06ab"},
+    {file = "pandas-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:32cc41f310ebd4a296d93515fcac312216adfedb1894e879303987b8f1e2b97d"},
+    {file = "pandas-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:a4785e1d6547d8427c5208b748ae2efb64659a21bd82bf440d4262d02bfa02a4"},
+    {file = "pandas-3.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:08504503f7101300107ecdc8df73658e4347586db5cfdadabc1592e9d7e7a0fd"},
+    {file = "pandas-3.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b5918ba197c951dec132b0c5929a00c0bf05d5942f590d3c10a807f6e15a57d3"},
+    {file = "pandas-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d606a041c89c0a474a4702d532ab7e73a14fe35c8d427b972a625c8e46373668"},
+    {file = "pandas-3.0.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:710246ba0616e86891b58ab95f2495143bb2bc83ab6b06747c74216f583a6ac9"},
+    {file = "pandas-3.0.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d3cfe227c725b1f3dff4278b43d8c784656a42a9325b63af6b1492a8232209e"},
+    {file = "pandas-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c3b723df9087a9a9a840e263ebd9f88b64a12075d1bf2ea401a5a42f254f084d"},
+    {file = "pandas-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3096110bf9eac0070b7208465f2740e2d8a670d5cb6530b5bb884eca495fd39"},
+    {file = "pandas-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:07a10f5c36512eead51bc578eb3354ad17578b22c013d89a796ab5eee90cd991"},
+    {file = "pandas-3.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:5fdbfa05931071aba28b408e59226186b01eb5e92bea2ab78b65863ca3228d84"},
+    {file = "pandas-3.0.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:dbc20dea3b9e27d0e66d74c42b2d0c1bed9c2ffe92adea33633e3bedeb5ac235"},
+    {file = "pandas-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b75c347eff42497452116ce05ef461822d97ce5b9ff8df6edacb8076092c855d"},
+    {file = "pandas-3.0.2-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1478075142e83a5571782ad007fb201ed074bdeac7ebcc8890c71442e96adf7"},
+    {file = "pandas-3.0.2-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5880314e69e763d4c8b27937090de570f1fb8d027059a7ada3f7f8e98bdcb677"},
+    {file = "pandas-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b5329e26898896f06035241a626d7c335daa479b9bbc82be7c2742d048e41172"},
+    {file = "pandas-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:81526c4afd31971f8b62671442a4b2b51e0aa9acc3819c9f0f12a28b6fcf85f1"},
+    {file = "pandas-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:7cadd7e9a44ec13b621aec60f9150e744cfc7a3dd32924a7e2f45edff31823b0"},
+    {file = "pandas-3.0.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:db0dbfd2a6cdf3770aa60464d50333d8f3d9165b2f2671bcc299b72de5a6677b"},
+    {file = "pandas-3.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0555c5882688a39317179ab4a0ed41d3ebc8812ab14c69364bbee8fb7a3f6288"},
+    {file = "pandas-3.0.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01f31a546acd5574ef77fe199bc90b55527c225c20ccda6601cf6b0fd5ed597c"},
+    {file = "pandas-3.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:deeca1b5a931fdf0c2212c8a659ade6d3b1edc21f0914ce71ef24456ca7a6535"},
+    {file = "pandas-3.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f48afd9bb13300ffb5a3316973324c787054ba6665cda0da3fbd67f451995db"},
+    {file = "pandas-3.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c4d8458b97a35717b62469a4ea0e85abd5ed8687277f5ccfc67f8a5126f8c53"},
+    {file = "pandas-3.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:b35d14bb5d8285d9494fe93815a9e9307c0876e10f1e8e89ac5b88f728ec8dcf"},
+    {file = "pandas-3.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:63d141b56ef686f7f0d714cfb8de4e320475b86bf4b620aa0b7da89af8cbdbbb"},
+    {file = "pandas-3.0.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:140f0cffb1fa2524e874dde5b477d9defe10780d8e9e220d259b2c0874c89d9d"},
+    {file = "pandas-3.0.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae37e833ff4fed0ba352f6bdd8b73ba3ab3256a85e54edfd1ab51ae40cca0af8"},
+    {file = "pandas-3.0.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d888a5c678a419a5bb41a2a93818e8ed9fd3172246555c0b37b7cc27027effd"},
+    {file = "pandas-3.0.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b444dc64c079e84df91baa8bf613d58405645461cabca929d9178f2cd392398d"},
+    {file = "pandas-3.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4544c7a54920de8eeacaa1466a6b7268ecfbc9bc64ab4dbb89c6bbe94d5e0660"},
+    {file = "pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702"},
+    {file = "pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276"},
+    {file = "pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482"},
+    {file = "pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043"},
+]
+
+[package.dependencies]
+numpy = {version = ">=1.26.0", markers = "python_version < \"3.14\""}
+python-dateutil = ">=2.8.2"
+tzdata = {version = "*", markers = "sys_platform == \"win32\" or sys_platform == \"emscripten\""}
+
+[package.extras]
+all = ["PyQt5 (>=5.15.9)", "SQLAlchemy (>=2.0.36)", "adbc-driver-postgresql (>=1.2.0)", "adbc-driver-sqlite (>=1.2.0)", "beautifulsoup4 (>=4.12.3)", "bottleneck (>=1.4.2)", "fastparquet (>=2024.11.0)", "fsspec (>=2024.10.0)", "gcsfs (>=2024.10.0)", "html5lib (>=1.1)", "hypothesis (>=6.116.0)", "jinja2 (>=3.1.5)", "lxml (>=5.3.0)", "matplotlib (>=3.9.3)", "numba (>=0.60.0)", "numexpr (>=2.10.2)", "odfpy (>=1.4.1)", "openpyxl (>=3.1.5)", "psycopg2 (>=2.9.10)", "pyarrow (>=13.0.0)", "pyiceberg (>=0.8.1)", "pymysql (>=1.1.1)", "pyreadstat (>=1.2.8)", "pytest (>=8.3.4)", "pytest-xdist (>=3.6.1)", "python-calamine (>=0.3.0)", "pytz (>=2024.2)", "pyxlsb (>=1.0.10)", "qtpy (>=2.4.2)", "s3fs (>=2024.10.0)", "scipy (>=1.14.1)", "tables (>=3.10.1)", "tabulate (>=0.9.0)", "xarray (>=2024.10.0)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.2.0)", "zstandard (>=0.23.0)"]
+aws = ["s3fs (>=2024.10.0)"]
+clipboard = ["PyQt5 (>=5.15.9)", "qtpy (>=2.4.2)"]
+compression = ["zstandard (>=0.23.0)"]
+computation = ["scipy (>=1.14.1)", "xarray (>=2024.10.0)"]
+excel = ["odfpy (>=1.4.1)", "openpyxl (>=3.1.5)", "python-calamine (>=0.3.0)", "pyxlsb (>=1.0.10)", "xlrd (>=2.0.1)", "xlsxwriter (>=3.2.0)"]
+feather = ["pyarrow (>=13.0.0)"]
+fss = ["fsspec (>=2024.10.0)"]
+gcp = ["gcsfs (>=2024.10.0)"]
+hdf5 = ["tables (>=3.10.1)"]
+html = ["beautifulsoup4 (>=4.12.3)", "html5lib (>=1.1)", "lxml (>=5.3.0)"]
+iceberg = ["pyiceberg (>=0.8.1)"]
+mysql = ["SQLAlchemy (>=2.0.36)", "pymysql (>=1.1.1)"]
+output-formatting = ["jinja2 (>=3.1.5)", "tabulate (>=0.9.0)"]
+parquet = ["pyarrow (>=13.0.0)"]
+performance = ["bottleneck (>=1.4.2)", "numba (>=0.60.0)", "numexpr (>=2.10.2)"]
+plot = ["matplotlib (>=3.9.3)"]
+postgresql = ["SQLAlchemy (>=2.0.36)", "adbc-driver-postgresql (>=1.2.0)", "psycopg2 (>=2.9.10)"]
+pyarrow = ["pyarrow (>=13.0.0)"]
+spss = ["pyreadstat (>=1.2.8)"]
+sql-other = ["SQLAlchemy (>=2.0.36)", "adbc-driver-postgresql (>=1.2.0)", "adbc-driver-sqlite (>=1.2.0)"]
+test = ["hypothesis (>=6.116.0)", "pytest (>=8.3.4)", "pytest-xdist (>=3.6.1)"]
+timezone = ["pytz (>=2024.2)"]
+xml = ["lxml (>=5.3.0)"]
 
 [[package]]
 name = "pathspec"
@@ -1445,6 +1648,22 @@ files = [
 typing-extensions = "*"
 
 [[package]]
+name = "pyluach"
+version = "2.3.0"
+description = "A Python package for dealing with Hebrew (Jewish) calendar dates."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pyluach-2.3.0-py3-none-any.whl", hash = "sha256:4497b731aef59508b079dbf5f00bc5bf4329ac45090a6cd37b5a83756f0e69ab"},
+    {file = "pyluach-2.3.0.tar.gz", hash = "sha256:ec6e30669d1df50c9ca160486da44a8195bb4c7a5d3d533990d0c5b03accd281"},
+]
+
+[package.extras]
+doc = ["sphinx (>=6.1.3,<6.2.0)", "sphinx_rtd_theme (>=1.2.0,<1.3.0)"]
+test = ["beautifulsoup4", "flake8", "pytest", "pytest-cov"]
+
+[[package]]
 name = "pysocks"
 version = "1.7.1"
 description = "A Python SOCKS client module. See https://github.com/Anorov/PySocks for more information."
@@ -1496,6 +1715,21 @@ pytest = ">=6.1.0"
 [package.extras]
 docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
 
 [[package]]
 name = "python-discovery"
@@ -1734,6 +1968,18 @@ selenium = "*"
 test = ["pytest"]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 description = "Sniff out which async library your code is running under"
@@ -1792,6 +2038,18 @@ doc = ["reno", "sphinx"]
 test = ["pytest", "tornado (>=4.5)", "typeguard"]
 
 [[package]]
+name = "toolz"
+version = "1.1.0"
+description = "List processing tools and functional utilities"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8"},
+    {file = "toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b"},
+]
+
+[[package]]
 name = "trio"
 version = "0.33.0"
 description = "A friendly Python library for async concurrency and I/O"
@@ -1838,6 +2096,18 @@ groups = ["main", "dev"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.1"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+groups = ["main"]
+files = [
+    {file = "tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9"},
+    {file = "tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98"},
 ]
 
 [[package]]
@@ -2079,4 +2349,4 @@ redis = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "033f8032854e79aa65ae4e4ed0a8504117128c718fd04a8f767d511423cf4768"
+content-hash = "49d4afdac2f363d1aa5416b38880696c902d7e861ab2b18d2d6e45b66222e6c9"

--- a/poetry.lock
+++ b/poetry.lock
@@ -930,6 +930,7 @@ develop = false
 aiohttp = "^3.8.4"
 chromedriver-autoinstaller = "^0.6.2"
 dacite = "^1.8.1"
+exchange-calendars = "^4.13.2"
 selenium = "^4.11.2"
 selenium-stealth = "^1.0.6"
 tenacity = "^9.1.2"
@@ -937,8 +938,8 @@ tenacity = "^9.1.2"
 [package.source]
 type = "git"
 url = "ssh://git@github.com/hanchiang/market_data_api.git"
-reference = "1.4.0"
-resolved_reference = "f87fbfc1fcea250f49527d337993ed2e49688811"
+reference = "1.5.0"
+resolved_reference = "6c20642998e80f440ba67c51d8e65f0488ed5f61"
 
 [[package]]
 name = "multidict"
@@ -2349,4 +2350,4 @@ redis = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "49d4afdac2f363d1aa5416b38880696c902d7e861ab2b18d2d6e45b66222e6c9"
+content-hash = "b79c03a7b90c22596748b3c4fc9cf83b7a11d529f5970ac992a722d6cc7a8ef9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ pyee = "^9.0.4"
 redis = "^4.4.0"
 python-telegram-bot = {version = "20.3", allow-prereleases = true}
 exchange-calendars = "^4.13.2"
-market-data-library = {git = "ssh://git@github.com/hanchiang/market_data_api.git", rev = "1.4.0"}
+market-data-library = {git = "ssh://git@github.com/hanchiang/market_data_api.git", rev = "1.5.0"}
 
 [tool.poetry.extras]
 redis = ["hiredis"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ python-dotenv = "^0.21.0"
 pyee = "^9.0.4"
 redis = "^4.4.0"
 python-telegram-bot = {version = "20.3", allow-prereleases = true}
+exchange-calendars = "^4.13.2"
 market-data-library = {git = "ssh://git@github.com/hanchiang/market_data_api.git", rev = "1.4.0"}
 
 [tool.poetry.extras]

--- a/scripts/show_market_data_library_source.sh
+++ b/scripts/show_market_data_library_source.sh
@@ -12,18 +12,27 @@ unset POETRY_ACTIVE
 unset PYTHONHOME
 unset PYTHONPATH
 
-site_packages="$(poetry run python -c 'import site; print(next(path for path in site.getsitepackages() if path.endswith("site-packages")))' )"
-override_file="${site_packages}/market_data_library_local_override.pth"
+poetry run python - <<'PY'
+import importlib.metadata as metadata
+import json
+import os
 
-if [[ -f "${override_file}" ]]; then
-  override_target="$(head -n 1 "${override_file}")"
-  printf 'Dependency mode: local-sibling-override\n'
-  printf 'Override file: %s\n' "${override_file}"
-  printf 'Configured source: %s\n' "${override_target}"
-else
-  printf 'Dependency mode: git-installed-package\n'
-  printf 'Override file: not present\n'
-fi
+import market_data_library
 
-module_dir="$(poetry run python -c 'import os, market_data_library; print(os.path.realpath(os.path.dirname(market_data_library.__file__)))')"
-printf 'Imported module path: %s\n' "${module_dir}"
+dist = metadata.distribution('market-data-library')
+direct_url_text = dist.read_text('direct_url.json')
+mode = 'unknown'
+configured_source = 'unknown'
+
+if direct_url_text:
+    direct_url = json.loads(direct_url_text)
+    configured_source = direct_url.get('url', configured_source)
+    if direct_url.get('dir_info', {}).get('editable'):
+        mode = 'local-sibling-editable'
+    elif 'vcs_info' in direct_url:
+        mode = 'git-installed-package'
+
+print(f'Dependency mode: {mode}')
+print(f'Configured source: {configured_source}')
+print(f'Imported module path: {os.path.realpath(os.path.dirname(market_data_library.__file__))}')
+PY

--- a/scripts/use_git_market_data_library.sh
+++ b/scripts/use_git_market_data_library.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 git_repo="${MARKET_DATA_LIBRARY_GIT_REPO:-git+ssh://git@github.com/hanchiang/market_data_api.git}"
-git_ref="${MARKET_DATA_LIBRARY_GIT_REF:-1.4.0}"
+git_ref="${MARKET_DATA_LIBRARY_GIT_REF:-1.5.0}"
 
 cd "${repo_root}"
 

--- a/scripts/use_git_market_data_library.sh
+++ b/scripts/use_git_market_data_library.sh
@@ -14,8 +14,5 @@ unset POETRY_ACTIVE
 unset PYTHONHOME
 unset PYTHONPATH
 
-site_packages="$(poetry run python -c 'import site; print(next(path for path in site.getsitepackages() if path.endswith("site-packages")))' )"
-override_file="${site_packages}/market_data_library_local_override.pth"
-
-rm -f "${override_file}"
+poetry run python -m pip uninstall -y market-data-library >/dev/null 2>&1 || true
 poetry run python -m pip install --force-reinstall "market-data-library @ ${git_repo}@${git_ref}"

--- a/scripts/use_local_market_data_library.sh
+++ b/scripts/use_local_market_data_library.sh
@@ -18,10 +18,8 @@ unset POETRY_ACTIVE
 unset PYTHONHOME
 unset PYTHONPATH
 
-site_packages="$(poetry run python -c 'import site; print(next(path for path in site.getsitepackages() if path.endswith("site-packages")))' )"
-override_file="${site_packages}/market_data_library_local_override.pth"
-
 poetry run python -m pip uninstall -y market-data-library >/dev/null 2>&1 || true
-printf '%s\n' "${library_root}" > "${override_file}"
+poetry run python -m pip install --no-deps --editable "${library_root}" >/dev/null
 
-echo "Using local market-data-library from ${library_root}"
+echo "Using local editable market-data-library from ${library_root}"
+echo "Re-run this script after poetry install if Poetry reinstalls the git dependency."

--- a/src/service/stocks_sentiment.py
+++ b/src/service/stocks_sentiment.py
@@ -1,3 +1,5 @@
+import calendar
+import datetime
 import logging
 from statistics import mean
 from typing import List, Optional
@@ -6,10 +8,11 @@ import src.util.date_util as date_util
 from market_data_library.types import cnn_type
 
 from src.data_source.market_data_library import get_tradfi_api
-from src.type.sentiment import FearGreedResult, FearGreedData, FearGreedAverage
-from src.util.list_util import is_list_out_of_range
+from src.type.sentiment import FearGreedAverage, FearGreedData, FearGreedResult
 
-logger = logging.getLogger('Stocks sentiment service')
+logger = logging.getLogger("Stocks sentiment service")
+
+
 class StocksSentimentService:
     def __init__(self):
         tradfi_api = get_tradfi_api()
@@ -17,111 +20,176 @@ class StocksSentimentService:
         self.cnn_service = cnn_api.cnn_service
         self.cnc_type = cnn_type
 
-    # TODO: cache
     async def get_stocks_fear_greed_index(self) -> Optional[FearGreedResult]:
-        fear_greed_res: cnn_type.CnnFearGreedIndex = await self.get_stocks_fear_greed_index_from_source()
+        fear_greed_res: cnn_type.CnnFearGreedIndex = (
+            await self.get_stocks_fear_greed_index_from_source()
+        )
 
-        if fear_greed_res is None or fear_greed_res.fear_and_greed is None or fear_greed_res.fear_and_greed_historical is None:
+        if (
+            fear_greed_res is None
+            or fear_greed_res.fear_and_greed is None
+            or fear_greed_res.fear_and_greed_historical is None
+        ):
             return None
 
-        # data does not include weekends
-        fear_and_greed_historical = fear_greed_res.fear_and_greed_historical
-        fear_and_greed_historical_with_weekends = []
-
-
-        # Fill in missing weekends with dummy data.
-        # Note that calculating average historical results won't be accurate because weekends(i.e. dummy data) are included
-        for i in range(0, len(fear_and_greed_historical.data)):
-            historical_data = fear_and_greed_historical.data[i]
-            dt = date_util.parse_timestamp(historical_data.x / 1000)
-            fear_and_greed_historical_with_weekends.append(historical_data)
-            # friday, add dummy data for saturday and sunday
-            if dt.weekday() == 4:
-                fear_and_greed_historical_with_weekends.append(historical_data)
-                fear_and_greed_historical_with_weekends.append(historical_data)
-
-        logger.info(
-            f'Retrieved {len(fear_and_greed_historical.data)} historical data, adjusted with weekends to {len(fear_and_greed_historical_with_weekends)}')
-        fear_and_greed_historical.data = fear_and_greed_historical_with_weekends
-
+        historical_data = fear_greed_res.fear_and_greed_historical.data
+        logger.info("Retrieved %s historical fear and greed data points", len(historical_data))
 
         data = self.transform_data(data=fear_greed_res)
         average = self.transform_average(data=fear_greed_res)
-        res = FearGreedResult(data=data, average=average)
-
-        return res
-
+        return FearGreedResult(data=data, average=average)
 
     def transform_data(self, data: cnn_type.CnnFearGreedIndex) -> List[FearGreedData]:
+        historical_data = data.fear_and_greed_historical.data
+        if len(historical_data) == 0:
+            return []
+
+        anchor_entry = historical_data[-1]
+        anchor_date = self._entry_datetime(anchor_entry).date()
+
         parse_params = [
-            {'text': 'Previous close', 'list_index': -1},
-            {'text': 'Last week', 'list_index': -8},
-            {'text': 'Last month', 'list_index': -31},
-            {'text': 'Last 3 months', 'list_index': -91},
-            {'text': 'Last year', 'list_index': self._get_last_year_list_index(data=data)},
+            ("Previous close", anchor_entry),
+            (
+                "Last week",
+                self._get_entry_at_or_before(
+                    historical_data,
+                    anchor_date - datetime.timedelta(days=7),
+                ),
+            ),
+            (
+                "Last month",
+                self._get_entry_at_or_before(
+                    historical_data,
+                    self._subtract_months(anchor_date, 1),
+                ),
+            ),
+            (
+                "Last 3 months",
+                self._get_entry_at_or_before(
+                    historical_data,
+                    self._subtract_months(anchor_date, 3),
+                ),
+            ),
+            (
+                "Last year",
+                self._get_entry_at_or_before(
+                    historical_data,
+                    self._subtract_years(anchor_date, 1),
+                ),
+            ),
         ]
 
-        res: List[FearGreedData] = []
+        result: List[FearGreedData] = []
 
-        for param in parse_params:
-            if is_list_out_of_range(data=data.fear_and_greed_historical.data, index=param['list_index']):
+        for label, entry in parse_params:
+            if entry is None:
                 continue
-            date = date_util.parse_timestamp(data.fear_and_greed_historical.data[param['list_index']].x / 1000)
 
-            value = data.fear_and_greed_historical.data[param['list_index']].y
+            value = entry.y
             sentiment = self.cnn_service.map_fear_greed_to_text(value=value)
-
             parsed = FearGreedData(
-                relative_date_text=param['text'],
-                date=date,
-                value=value
+                relative_date_text=label,
+                date=self._entry_datetime(entry),
+                value=value,
             )
             if sentiment is not None:
-                parsed.sentiment_text = sentiment['text']
-                parsed.emoji = sentiment['emoji']
+                parsed.sentiment_text = sentiment["text"]
+                parsed.emoji = sentiment["emoji"]
 
-            res.append(parsed)
-        return res
+            result.append(parsed)
+        return result
 
-    def transform_average(self, data: cnn_type.CnnFearGreedIndex) -> List[FearGreedAverage]:
+    def transform_average(
+        self,
+        data: cnn_type.CnnFearGreedIndex,
+    ) -> List[FearGreedAverage]:
+        historical_data = data.fear_and_greed_historical.data
+        if len(historical_data) == 0:
+            return []
+
+        anchor_date = self._entry_datetime(historical_data[-1]).date()
         average_params = [
-            {'timeframe': '1 week', 'list_end_index': -7},
-            {'timeframe': '1 month', 'list_end_index': -30},
-            {'timeframe': '3 months', 'list_end_index': -90},
-            {'timeframe': '1 year', 'list_end_index': self._get_last_year_list_index(data=data)}
+            ("1 week", anchor_date - datetime.timedelta(days=7)),
+            ("1 month", self._subtract_months(anchor_date, 1)),
+            ("3 months", self._subtract_months(anchor_date, 3)),
+            ("1 year", self._subtract_years(anchor_date, 1)),
         ]
 
-        res: List[FearGreedAverage] = []
+        result: List[FearGreedAverage] = []
 
-        for param in average_params:
-            if is_list_out_of_range(data=data.fear_and_greed_historical.data, index=param['list_end_index']):
-                continue
-            historical_range_data = data.fear_and_greed_historical.data[param['list_end_index']:-1]
-            historical_score = [d.y for d in historical_range_data]
-            average = mean(historical_score)
-            sentiment = self.cnn_service.map_fear_greed_to_text(value=average)
-
-            parsed = FearGreedAverage(
-                timeframe=param['timeframe'],
-                value=average
+        for timeframe, window_start in average_params:
+            entries_in_window = self._get_entries_in_window(
+                historical_data=historical_data,
+                window_start=window_start,
+                anchor_date=anchor_date,
             )
+            if len(entries_in_window) == 0:
+                continue
 
+            average_value = mean(entry.y for entry in entries_in_window)
+            sentiment = self.cnn_service.map_fear_greed_to_text(value=average_value)
+            parsed = FearGreedAverage(
+                timeframe=timeframe,
+                value=average_value,
+            )
             if sentiment is not None:
-                parsed.sentiment_text = sentiment['text']
-                parsed.emoji = sentiment['emoji']
+                parsed.sentiment_text = sentiment["text"]
+                parsed.emoji = sentiment["emoji"]
 
-            res.append(parsed)
+            result.append(parsed)
 
-        return res
+        return result
 
-    def _get_last_year_list_index(self, data: cnn_type.CnnFearGreedIndex):
-        last_year_list_index = -365
-        if len(data.fear_and_greed_historical.data) > 200 and len(data.fear_and_greed_historical.data) < abs(last_year_list_index):
-            logger.info(
-                f'Last year list index is {last_year_list_index} while length of fear greed historical data is {len(data.fear_and_greed_historical.data)}. Setting last year list index to 0')
-            last_year_list_index = 0
-        return last_year_list_index
+    def _get_entry_at_or_before(
+        self,
+        historical_data: List[cnn_type.FearAndGreedHistoricalData],
+        target_date: datetime.date,
+    ) -> Optional[cnn_type.FearAndGreedHistoricalData]:
+        for entry in reversed(historical_data):
+            if self._entry_datetime(entry).date() <= target_date:
+                return entry
+        return None
+
+    def _get_entries_in_window(
+        self,
+        historical_data: List[cnn_type.FearAndGreedHistoricalData],
+        window_start: datetime.date,
+        anchor_date: datetime.date,
+    ) -> List[cnn_type.FearAndGreedHistoricalData]:
+        return [
+            entry
+            for entry in historical_data
+            if window_start < self._entry_datetime(entry).date() <= anchor_date
+        ]
+
+    def _entry_datetime(
+        self,
+        entry: cnn_type.FearAndGreedHistoricalData,
+    ) -> datetime.datetime:
+        return date_util.parse_timestamp(entry.x / 1000)
+
+    def _subtract_months(
+        self,
+        reference_date: datetime.date,
+        months: int,
+    ) -> datetime.date:
+        month_index = reference_date.month - months
+        year = reference_date.year + (month_index - 1) // 12
+        month = ((month_index - 1) % 12) + 1
+        day = min(reference_date.day, calendar.monthrange(year, month)[1])
+        return datetime.date(year, month, day)
+
+    def _subtract_years(
+        self,
+        reference_date: datetime.date,
+        years: int,
+    ) -> datetime.date:
+        year = reference_date.year - years
+        day = min(reference_date.day, calendar.monthrange(year, reference_date.month)[1])
+        return datetime.date(year, reference_date.month, day)
 
     async def get_stocks_fear_greed_index_from_source(self) -> cnn_type.CnnFearGreedIndex:
-        fear_greed_res: cnn_type.CnnFearGreedIndex = await self.cnn_service.get_fear_greed_index()
+        fear_greed_res: cnn_type.CnnFearGreedIndex = (
+            await self.cnn_service.get_fear_greed_index()
+        )
         return fear_greed_res

--- a/src/util/date_util.py
+++ b/src/util/date_util.py
@@ -1,41 +1,90 @@
 import datetime
-import pytz
+from typing import cast
+from zoneinfo import ZoneInfo
 
-ny_tz = pytz.timezone('America/New_York')
+import exchange_calendars as xcals
+from market_data_library.util import date_util as market_data_library_date_util
+
+ny_tz = ZoneInfo("America/New_York")
+XNYS_CALENDAR = xcals.get_calendar("XNYS")
+
 
 def get_current_datetime():
     now = datetime.datetime.now()
     return now.astimezone(tz=ny_tz)
 
+
 def get_current_date():
-    now = datetime.datetime.now().astimezone(tz=ny_tz).replace(hour=0, minute=0, second=0, microsecond=0)
-    return now
+    now = datetime.datetime.now().astimezone(tz=ny_tz)
+    return now.replace(hour=0, minute=0, second=0, microsecond=0)
+
 
 def get_current_date_preserve_time():
     now = datetime.datetime.now().astimezone(tz=ny_tz)
     return now
 
+
 def get_datetime_from_timestamp(timestamp: int, use_ny_tz=True) -> datetime.datetime:
     return datetime.datetime.fromtimestamp(timestamp, tz=ny_tz if use_ny_tz else None)
 
-def format(dt: datetime.datetime, format = '%Y-%m-%d') -> str:
+
+def format(dt: datetime.datetime, format="%Y-%m-%d") -> str:
     return dt.strftime(format)
 
-def parse_timestamp(unix_ts: float, tz: datetime.timezone = datetime.timezone.utc) -> datetime.datetime:
+
+def parse_timestamp(
+    unix_ts: float,
+    tz: datetime.timezone = datetime.timezone.utc,
+) -> datetime.datetime:
     return datetime.datetime.fromtimestamp(unix_ts, tz=tz)
 
-def parse(dt: str, format: str, tz: datetime.timezone=datetime.timezone.utc) -> datetime.datetime:
+
+def parse(
+    dt: str,
+    format: str,
+    tz: datetime.timezone = datetime.timezone.utc,
+) -> datetime.datetime:
     return datetime.datetime.strptime(dt, format).replace(tzinfo=tz)
 
-# return the most recent non-weekend or today
-# TODO: exclude public holidays
-def get_most_recent_non_weekend_or_today(date: datetime.datetime) -> datetime.datetime:
-    # Monday == 0, Sunday == 6
-    day_of_week = date.weekday()
-    days_to_subtract = 0
-    if day_of_week == 5:
-        days_to_subtract = 1
-    elif day_of_week == 6:
-        days_to_subtract = 2
 
-    return date - datetime.timedelta(days=days_to_subtract)
+def _fallback_get_trading_day_at_or_before(
+    reference_date: datetime.date | datetime.datetime,
+) -> datetime.date:
+    normalized_date = (
+        reference_date.date()
+        if isinstance(reference_date, datetime.datetime)
+        else reference_date
+    )
+    session = XNYS_CALENDAR.date_to_session(
+        normalized_date.isoformat(),
+        direction="previous",
+    )
+    return cast(datetime.date, session.date())
+
+
+def _get_trading_day_at_or_before(
+    reference_date: datetime.date | datetime.datetime,
+) -> datetime.date:
+    # Prefer the shared library helper so backend behavior tracks the published
+    # library contract once that release is available. Keep the local fallback
+    # for the current pinned git dependency until the library change is merged
+    # and the backend dependency is advanced to include it.
+    shared_helper = getattr(
+        market_data_library_date_util,
+        "get_trading_day_at_or_before",
+        None,
+    )
+    if shared_helper is not None:
+        return shared_helper(reference_date)
+
+    # Keep the backend compatible with released library pins until they catch up.
+    return _fallback_get_trading_day_at_or_before(reference_date)
+
+
+def get_most_recent_non_weekend_or_today(date: datetime.datetime) -> datetime.datetime:
+    target_date = _get_trading_day_at_or_before(date)
+    return date.replace(
+        year=target_date.year,
+        month=target_date.month,
+        day=target_date.day,
+    )

--- a/tests/unit/dependencies_test.py
+++ b/tests/unit/dependencies_test.py
@@ -1,0 +1,123 @@
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from src.dependencies import Dependencies
+
+
+@pytest.fixture(autouse=True)
+def reset_dependencies_state():
+    original_values = {
+        "is_initialised": Dependencies.is_initialised,
+        "tradingview_service": Dependencies.tradingview_service,
+        "thirdparty_vix_central_service": Dependencies.thirdparty_vix_central_service,
+        "vix_central_service": Dependencies.vix_central_service,
+        "thirdparty_barchart_service": Dependencies.thirdparty_barchart_service,
+        "barchart_service": Dependencies.barchart_service,
+        "stocks_sentiment_service": Dependencies.stocks_sentiment_service,
+        "cryptoquant_api_service": Dependencies.cryptoquant_api_service,
+        "crypto_sentiment_service": Dependencies.crypto_sentiment_service,
+        "crypto_stats_service": Dependencies.crypto_stats_service,
+    }
+
+    Dependencies.is_initialised = False
+    Dependencies.tradingview_service = None
+    Dependencies.thirdparty_vix_central_service = None
+    Dependencies.vix_central_service = None
+    Dependencies.thirdparty_barchart_service = None
+    Dependencies.barchart_service = None
+    Dependencies.stocks_sentiment_service = None
+    Dependencies.cryptoquant_api_service = None
+    Dependencies.crypto_sentiment_service = None
+    Dependencies.crypto_stats_service = None
+
+    try:
+        yield
+    finally:
+        for name, value in original_values.items():
+            setattr(Dependencies, name, value)
+
+
+@pytest.mark.asyncio
+async def test_build_and_cleanup_wire_dependencies_without_live_clients(monkeypatch):
+    tradingview_service = Mock()
+    vix_http_client = Mock()
+    thirdparty_vix_central_service = Mock()
+    thirdparty_barchart_service = Mock()
+    vix_central_service = Mock()
+    vix_central_service.cleanup = AsyncMock()
+    barchart_service = Mock()
+    barchart_service.cleanup = AsyncMock()
+    stocks_sentiment_service = Mock()
+    cryptoquant_underlying_service = Mock()
+    cryptoquant_underlying_service.cleanup = AsyncMock()
+    cryptoquant_service = Mock(cryptoquant_service=cryptoquant_underlying_service)
+    crypto_sentiment_service = Mock()
+    crypto_stats_service = Mock()
+
+    build_http_client = AsyncMock(return_value=vix_http_client)
+    tradingview_cls = Mock(return_value=tradingview_service)
+    thirdparty_vix_cls = Mock(return_value=thirdparty_vix_central_service)
+    vix_central_cls = Mock(return_value=vix_central_service)
+    thirdparty_barchart_cls = Mock(return_value=thirdparty_barchart_service)
+    barchart_cls = Mock(return_value=barchart_service)
+    stocks_sentiment_cls = Mock(return_value=stocks_sentiment_service)
+    cryptoquant_cls = Mock(return_value=cryptoquant_service)
+    crypto_sentiment_cls = Mock(return_value=crypto_sentiment_service)
+    crypto_stats_cls = Mock(return_value=crypto_stats_service)
+
+    monkeypatch.setattr("src.dependencies.HttpClient.create", build_http_client)
+    monkeypatch.setattr("src.dependencies.TradingViewService", tradingview_cls)
+    monkeypatch.setattr(
+        "src.dependencies.ThirdPartyVixCentralService",
+        thirdparty_vix_cls,
+    )
+    monkeypatch.setattr("src.dependencies.VixCentralService", vix_central_cls)
+    monkeypatch.setattr(
+        "src.dependencies.ThirdPartyBarchartService",
+        thirdparty_barchart_cls,
+    )
+    monkeypatch.setattr("src.dependencies.BarchartService", barchart_cls)
+    monkeypatch.setattr(
+        "src.dependencies.StocksSentimentService",
+        stocks_sentiment_cls,
+    )
+    monkeypatch.setattr("src.dependencies.CryptoQuantService", cryptoquant_cls)
+    monkeypatch.setattr(
+        "src.dependencies.CryptoSentimentService",
+        crypto_sentiment_cls,
+    )
+    monkeypatch.setattr("src.dependencies.CryptoStatsService", crypto_stats_cls)
+
+    await Dependencies.build()
+    await Dependencies.build()
+
+    assert Dependencies.is_initialised is True
+    build_http_client.assert_awaited_once()
+    tradingview_cls.assert_called_once_with()
+    thirdparty_vix_cls.assert_called_once_with(http_client=vix_http_client)
+    vix_central_cls.assert_called_once_with(
+        third_party_service=thirdparty_vix_central_service
+    )
+    thirdparty_barchart_cls.assert_called_once_with()
+    barchart_cls.assert_called_once_with(
+        third_party_service=thirdparty_barchart_service
+    )
+    stocks_sentiment_cls.assert_called_once_with()
+    cryptoquant_cls.assert_called_once_with()
+    crypto_sentiment_cls.assert_called_once_with()
+    crypto_stats_cls.assert_called_once_with()
+
+    assert Dependencies.get_tradingview_service() is tradingview_service
+    assert Dependencies.get_vix_central_service() is vix_central_service
+    assert Dependencies.get_barchart_service() is barchart_service
+    assert Dependencies.get_stocks_sentiment_service() is stocks_sentiment_service
+    assert Dependencies.get_cryptoquant_api_service() is cryptoquant_service
+    assert Dependencies.get_crypto_sentiment_service() is crypto_sentiment_service
+    assert Dependencies.get_crypto_stats_service() is crypto_stats_service
+
+    await Dependencies.cleanup()
+
+    vix_central_service.cleanup.assert_awaited_once()
+    barchart_service.cleanup.assert_awaited_once()
+    cryptoquant_underlying_service.cleanup.assert_awaited_once()

--- a/tests/unit/job/crypto/crypto_digest_message_sender_test.py
+++ b/tests/unit/job/crypto/crypto_digest_message_sender_test.py
@@ -1,4 +1,3 @@
-import asyncio
 import copy
 import dataclasses
 import datetime
@@ -11,7 +10,6 @@ import pytest
 from dacite import from_dict
 from market_data_library.types import cmc_type
 
-from src.dependencies import Dependencies
 from src.job.crypto.crypto_digest_message_sender import CryptoDigestMessageSender
 from src.type.sentiment import FearGreedAverage, FearGreedData, FearGreedResult
 
@@ -164,13 +162,11 @@ class TestCryptoDigestMessageSender:
             coins=coins,
         )
 
-    @classmethod
-    def setup_class(cls):
-        asyncio.run(Dependencies.build())
-
-    @classmethod
-    def teardown_class(cls):
-        asyncio.run(Dependencies.cleanup())
+    def build_message_sender(self):
+        message_sender = object.__new__(CryptoDigestMessageSender)
+        message_sender.cmc_service = AsyncMock()
+        message_sender.sentiment_service = AsyncMock()
+        return message_sender
 
     @pytest.mark.asyncio
     async def test_format_message_builds_single_digest(self):
@@ -220,7 +216,7 @@ class TestCryptoDigestMessageSender:
             ),
         }
 
-        message_sender = CryptoDigestMessageSender()
+        message_sender = self.build_message_sender()
         message_sender.sentiment_service.get_crypto_fear_greed_index = AsyncMock(
             return_value=self.sentiment
         )
@@ -311,7 +307,7 @@ class TestCryptoDigestMessageSender:
             ),
         }
 
-        message_sender = CryptoDigestMessageSender()
+        message_sender = self.build_message_sender()
         message_sender.sentiment_service.get_crypto_fear_greed_index = AsyncMock(
             return_value=self.sentiment
         )
@@ -388,7 +384,7 @@ class TestCryptoDigestMessageSender:
             ),
         }
 
-        message_sender = CryptoDigestMessageSender()
+        message_sender = self.build_message_sender()
         message_sender.sentiment_service.get_crypto_fear_greed_index = AsyncMock(
             return_value=self.sentiment
         )
@@ -454,7 +450,7 @@ class TestCryptoDigestMessageSender:
             ),
         }
 
-        message_sender = CryptoDigestMessageSender()
+        message_sender = self.build_message_sender()
         message_sender.sentiment_service.get_crypto_fear_greed_index = AsyncMock(
             return_value=self.sentiment
         )
@@ -501,7 +497,7 @@ class TestCryptoDigestMessageSender:
         weakest_sector.gainersNum = '1'
         weakest_sector.losersNum = '14'
 
-        message_sender = CryptoDigestMessageSender()
+        message_sender = self.build_message_sender()
         message_sender.sentiment_service.get_crypto_fear_greed_index = AsyncMock(
             return_value=self.sentiment
         )
@@ -544,7 +540,7 @@ class TestCryptoDigestMessageSender:
         weakest_sector.title = 'Music'
         weakest_sector.avgPriceChange = -7.4
 
-        message_sender = CryptoDigestMessageSender()
+        message_sender = self.build_message_sender()
         message_sender.sentiment_service.get_crypto_fear_greed_index = AsyncMock(
             return_value=self.sentiment
         )

--- a/tests/unit/service/barchart_test.py
+++ b/tests/unit/service/barchart_test.py
@@ -1,22 +1,25 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 from src.service.barchart import BarchartService
-from src.third_party_service.barchart import ThirdPartyBarchartService
 from market_data_library.types import barchart_type
+
 
 class TestBarchartService:
     @pytest.mark.asyncio
     async def test_get_stock_price(self):
-        service = BarchartService(third_party_service=ThirdPartyBarchartService())
-        service.third_party_service.get_stock_price = AsyncMock(return_value=[
-            barchart_type.StockPrice(symbol='SPY', date='2023-06-09', open_price=429.96, high_price=431.99, low_price=428.87, close_price=429.9, volume=85647200.0),
-            barchart_type.StockPrice(symbol='SPY', date='2023-06-08', open_price=426.62, high_price=429.6, low_price=425.82, close_price=429.13, volume=61952800.0)
-            ])
+        third_party_service = Mock()
+        third_party_service.get_stock_price = AsyncMock(
+            return_value=[
+                barchart_type.StockPrice(symbol='SPY', date='2023-06-09', open_price=429.96, high_price=431.99, low_price=428.87, close_price=429.9, volume=85647200.0),
+                barchart_type.StockPrice(symbol='SPY', date='2023-06-08', open_price=426.62, high_price=429.6, low_price=425.82, close_price=429.13, volume=61952800.0),
+            ]
+        )
+        service = BarchartService(third_party_service=third_party_service)
         res = await service.get_stock_price(symbol='SPY')
 
         assert res == [
             barchart_type.StockPrice(symbol='SPY', date='2023-06-09', open_price=429.96, high_price=431.99, low_price=428.87, close_price=429.9, volume=85647200.0),
-            barchart_type.StockPrice(symbol='SPY', date='2023-06-08', open_price=426.62, high_price=429.6, low_price=425.82, close_price=429.13, volume=61952800.0)
-            ]
+            barchart_type.StockPrice(symbol='SPY', date='2023-06-08', open_price=426.62, high_price=429.6, low_price=425.82, close_price=429.13, volume=61952800.0),
+        ]

--- a/tests/unit/service/crypto_sentiment_test.py
+++ b/tests/unit/service/crypto_sentiment_test.py
@@ -1,24 +1,14 @@
-import asyncio
 import datetime
 from unittest.mock import Mock, AsyncMock
 
 import pytest
 from market_data_library.types import alternativeme_type
 
-from src.dependencies import Dependencies
 from src.service.crypto.crypto_sentiment import CryptoSentimentService
 from src.type.sentiment import FearGreedResult, FearGreedData
 
 
 class TestCryptoSentimentService:
-
-    @classmethod
-    def setup_class(cls):
-        asyncio.run(Dependencies.build())
-
-    @classmethod
-    def teardown_class(cls):
-        asyncio.run(Dependencies.cleanup())
 
     @pytest.mark.parametrize(
         'data, expected',
@@ -51,7 +41,7 @@ class TestCryptoSentimentService:
     )
     @pytest.mark.asyncio
     async def test_get_crypto_fear_greed_index(self, data, expected):
-        service = CryptoSentimentService()
+        service = object.__new__(CryptoSentimentService)
         service.alternativeme_service = Mock()
 
         service.alternativeme_service.get_fear_greed_index = AsyncMock(return_value=data)
@@ -59,4 +49,3 @@ class TestCryptoSentimentService:
 
         res = await service.get_crypto_fear_greed_index()
         assert res == expected
-

--- a/tests/unit/service/crypto_stats_test.py
+++ b/tests/unit/service/crypto_stats_test.py
@@ -8,6 +8,7 @@ from market_data_library.types import cmc_type
 
 from src.service.crypto.crypto_stats import CryptoStatsService
 
+
 class TestCryptoStatsService:
 
     def setup_method(self):
@@ -29,7 +30,9 @@ class TestCryptoStatsService:
     ])
     @pytest.mark.asyncio
     async def test_get_sectors_24h_change(self, sort_by, sort_direction, limit):
-        self.service = CryptoStatsService()
+        self.service = object.__new__(CryptoStatsService)
+        self.service.cmc_type = cmc_type
+        self.service.cmc_service = AsyncMock()
         self.service.cmc_service.get_sector_24h_change = AsyncMock(return_value=self.sector_24h_change)
         res = await self.service.get_sectors_24h_change(sort_by=sort_by, sort_direction=sort_direction, limit=limit)
         assert res == self.sector_24h_change.data[:limit]

--- a/tests/unit/service/stocks_sentiment_test.py
+++ b/tests/unit/service/stocks_sentiment_test.py
@@ -1,4 +1,3 @@
-import asyncio
 import datetime
 from unittest.mock import AsyncMock, Mock
 

--- a/tests/unit/service/stocks_sentiment_test.py
+++ b/tests/unit/service/stocks_sentiment_test.py
@@ -1,78 +1,145 @@
 import asyncio
 import datetime
-from unittest.mock import Mock, AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from market_data_library.types import cnn_type
 
-from src.dependencies import Dependencies
 from src.service.stocks_sentiment import StocksSentimentService
-from src.type.sentiment import FearGreedResult, FearGreedData
+from src.type.sentiment import FearGreedAverage, FearGreedData, FearGreedResult
 
 
 class TestStocksSentimentService:
-
-    @classmethod
-    def setup_class(cls):
-        asyncio.run(Dependencies.build())
-
-    @classmethod
-    def teardown_class(cls):
-        asyncio.run(Dependencies.cleanup())
-
     @pytest.mark.parametrize(
-        'data, expected',
+        ("data", "expected"),
         [
             (
-                    cnn_type.CnnFearGreedIndex(
-                        fear_and_greed=cnn_type.FearAndGreed(
-                            previous_1_month=79,
-                            previous_1_week=77,
-                            previous_1_year=60,
-                            previous_close=73,
-                            rating='greed',
-                            score=68,
-                            timestamp='2023-08-04T23:59:56+00:00',
-                        ),
-                        fear_and_greed_historical=cnn_type.FearAndGreedHistorical(
-                            data=[
-                                cnn_type.FearAndGreedHistoricalData(
-                                    rating='greed',
-                                    x=1691107200000,
-                                    y=63
-                                ),
-                                cnn_type.FearAndGreedHistoricalData(
-                                    rating='greed',
-                                    x=1691193596000,
-                                    y=65
-                                )
-                            ],
-                            rating='greed',
-                            score=65,
-                            timestamp=1691193596000
-                        )
+                cnn_type.CnnFearGreedIndex(
+                    fear_and_greed=cnn_type.FearAndGreed(
+                        previous_1_month=79,
+                        previous_1_week=77,
+                        previous_1_year=60,
+                        previous_close=73,
+                        rating="greed",
+                        score=68,
+                        timestamp="2023-08-04T23:59:56+00:00",
                     ),
-                    FearGreedResult(data=[
+                    fear_and_greed_historical=cnn_type.FearAndGreedHistorical(
+                        data=[
+                            cnn_type.FearAndGreedHistoricalData(
+                                rating="neutral",
+                                x=1736726400000,  # 2025-01-13
+                                y=10,
+                            ),
+                            cnn_type.FearAndGreedHistoricalData(
+                                rating="neutral",
+                                x=1736812800000,  # 2025-01-14
+                                y=20,
+                            ),
+                            cnn_type.FearAndGreedHistoricalData(
+                                rating="neutral",
+                                x=1736899200000,  # 2025-01-15
+                                y=30,
+                            ),
+                            cnn_type.FearAndGreedHistoricalData(
+                                rating="neutral",
+                                x=1736985600000,  # 2025-01-16
+                                y=40,
+                            ),
+                            cnn_type.FearAndGreedHistoricalData(
+                                rating="neutral",
+                                x=1737072000000,  # 2025-01-17
+                                y=50,
+                            ),
+                            cnn_type.FearAndGreedHistoricalData(
+                                rating="greed",
+                                x=1737417600000,  # 2025-01-21 after MLK Day
+                                y=60,
+                            ),
+                        ],
+                        rating="greed",
+                        score=60,
+                        timestamp=1737460800000,
+                    ),
+                ),
+                FearGreedResult(
+                    data=[
                         FearGreedData(
-                            relative_date_text='Previous close',
-                            date=datetime.datetime(2023, 8, 4, 23, 59, 56, tzinfo=datetime.timezone.utc),
-                            value=65,
-                            sentiment_text='Greed',
-                            emoji='🤑'
-                        )],
-                        average=[]
-                    )
+                            relative_date_text="Previous close",
+                            date=datetime.datetime(
+                                2025,
+                                1,
+                                21,
+                                0,
+                                0,
+                                tzinfo=datetime.timezone.utc,
+                            ),
+                            value=60,
+                            sentiment_text="Greed",
+                            emoji="🤑",
+                        ),
+                        FearGreedData(
+                            relative_date_text="Last week",
+                            date=datetime.datetime(
+                                2025,
+                                1,
+                                14,
+                                0,
+                                0,
+                                tzinfo=datetime.timezone.utc,
+                            ),
+                            value=20,
+                            sentiment_text="Fear",
+                            emoji="😨",
+                        ),
+                    ],
+                    average=[
+                        FearGreedAverage(
+                            timeframe="1 week",
+                            value=45,
+                            sentiment_text="Neutral",
+                            emoji="😐",
+                        ),
+                        FearGreedAverage(
+                            timeframe="1 month",
+                            value=35,
+                            sentiment_text="Neutral",
+                            emoji="😐",
+                        ),
+                        FearGreedAverage(
+                            timeframe="3 months",
+                            value=35,
+                            sentiment_text="Neutral",
+                            emoji="😐",
+                        ),
+                        FearGreedAverage(
+                            timeframe="1 year",
+                            value=35,
+                            sentiment_text="Neutral",
+                            emoji="😐",
+                        ),
+                    ],
+                ),
             )
-        ]
+        ],
     )
     @pytest.mark.asyncio
     async def test_get_stocks_fear_greed_index(self, data, expected):
-        service = StocksSentimentService()
+        service = object.__new__(StocksSentimentService)
         service.cnn_service = Mock()
+        service.cnc_type = cnn_type
 
         service.cnn_service.get_fear_greed_index = AsyncMock(return_value=data)
-        service.cnn_service.map_fear_greed_to_text = Mock(return_value={ 'text': 'Greed', 'emoji': '🤑' })
+        service.cnn_service.map_fear_greed_to_text = Mock(
+            side_effect=[
+                {"text": "Greed", "emoji": "🤑"},
+                {"text": "Fear", "emoji": "😨"},
+                {"text": "Neutral", "emoji": "😐"},
+                {"text": "Neutral", "emoji": "😐"},
+                {"text": "Neutral", "emoji": "😐"},
+                {"text": "Neutral", "emoji": "😐"},
+            ]
+        )
 
         res = await service.get_stocks_fear_greed_index()
         assert res == expected
-

--- a/tests/unit/service/tradingview_service_test.py
+++ b/tests/unit/service/tradingview_service_test.py
@@ -1,9 +1,7 @@
-import asyncio
 from unittest.mock import Mock, patch, AsyncMock
 
 import pytest
 
-from src.dependencies import Dependencies
 from src.service.tradingview_service import TradingViewService
 from src.type.trading_view import TradingViewDataType, TradingViewData, TradingViewStocksData, TradingViewRedisData
 
@@ -11,13 +9,6 @@ from src.type.trading_view import TradingViewDataType, TradingViewData, TradingV
 class TestTradingViewService:
     def setup_method(self):
         self.tradingview_service = TradingViewService()
-    @classmethod
-    def setup_class(cls):
-        asyncio.run(Dependencies.build())
-
-    @classmethod
-    def teardown_class(cls):
-        asyncio.run(Dependencies.cleanup())
 
     @pytest.mark.parametrize(
         'redis_data, expected',

--- a/tests/unit/util/date_util_test.py
+++ b/tests/unit/util/date_util_test.py
@@ -1,5 +1,6 @@
 import datetime
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -8,11 +9,30 @@ from src.util.date_util import ny_tz
 
 
 class TestDateUtil:
+    @staticmethod
+    def build_utc_datetime(
+        year: int,
+        month: int,
+        day: int,
+        hour: int = 0,
+        minute: int = 0,
+        second: int = 0,
+        microsecond: int = 0,
+    ) -> datetime.datetime:
+        return datetime.datetime(
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            microsecond,
+            tzinfo=datetime.timezone.utc,
+        )
 
     @pytest.fixture
     def utc_now(self) -> datetime.datetime:
-        return datetime.datetime.utcnow().replace(year=2023, month=5, day=29, hour=21, minute=0, second=0,
-                                                  microsecond=0)
+        return self.build_utc_datetime(2023, 5, 29, 21, 0, 0, 0)
 
     @patch('src.util.date_util.datetime')
     def test_get_current_datetime(self, mock_datetime, utc_now):
@@ -36,36 +56,58 @@ class TestDateUtil:
 
     @pytest.mark.parametrize('input, expected', [
         (
-                datetime.datetime.utcnow().replace(year=2023, month=5, day=29, hour=21, minute=0, second=0,
-                                                   microsecond=0),  # monday
-                datetime.datetime.utcnow().replace(year=2023, month=5, day=29, hour=21, minute=0, second=0,
-                                                   microsecond=0),
+                build_utc_datetime.__func__(2023, 5, 29, 21, 0, 0, 0),  # Memorial Day
+                build_utc_datetime.__func__(2023, 5, 26, 21, 0, 0, 0),
         ),
         (
-                datetime.datetime.utcnow().replace(year=2023, month=5, day=28, hour=21, minute=0, second=0,
-                                                   microsecond=0),  # sunday
-                datetime.datetime.utcnow().replace(year=2023, month=5, day=26, hour=21, minute=0, second=0,
-                                                   microsecond=0),
+                build_utc_datetime.__func__(2023, 5, 28, 21, 0, 0, 0),  # sunday
+                build_utc_datetime.__func__(2023, 5, 26, 21, 0, 0, 0),
         ),
         (
-                datetime.datetime.utcnow().replace(year=2023, month=5, day=27, hour=21, minute=0, second=0,
-                                                   microsecond=0),  # saturday
-                datetime.datetime.utcnow().replace(year=2023, month=5, day=26, hour=21, minute=0, second=0,
-                                                   microsecond=0),
+                build_utc_datetime.__func__(2023, 5, 27, 21, 0, 0, 0),  # saturday
+                build_utc_datetime.__func__(2023, 5, 26, 21, 0, 0, 0),
         ),
         (
-                datetime.datetime.utcnow().replace(year=2023, month=5, day=26, hour=21, minute=0, second=0,
-                                                   microsecond=0),  # friday
-                datetime.datetime.utcnow().replace(year=2023, month=5, day=26, hour=21, minute=0, second=0,
-                                                   microsecond=0),
+                build_utc_datetime.__func__(2023, 5, 26, 21, 0, 0, 0),  # friday
+                build_utc_datetime.__func__(2023, 5, 26, 21, 0, 0, 0),
+        ),
+        (
+                build_utc_datetime.__func__(2025, 1, 20, 21, 0, 0, 0),  # MLK Day
+                build_utc_datetime.__func__(2025, 1, 17, 21, 0, 0, 0),
         )
     ])
     def test_get_most_recent_non_weekend_or_today(self, input, expected):
         res = date_util.get_most_recent_non_weekend_or_today(date=input)
         assert res == expected
 
+    def test_get_most_recent_non_weekend_or_today_uses_shared_library_helper(self, monkeypatch):
+        shared_helper = Mock(return_value=datetime.date(2025, 1, 17))
+        monkeypatch.setattr(
+            date_util,
+            'market_data_library_date_util',
+            SimpleNamespace(get_trading_day_at_or_before=shared_helper),
+        )
+        input_date = self.build_utc_datetime(2025, 1, 20, 21, 0, 0, 0)
+
+        res = date_util.get_most_recent_non_weekend_or_today(date=input_date)
+
+        shared_helper.assert_called_once_with(input_date)
+        assert res == self.build_utc_datetime(2025, 1, 17, 21, 0, 0, 0)
+
+    def test_get_most_recent_non_weekend_or_today_falls_back_when_library_helper_missing(self, monkeypatch):
+        monkeypatch.setattr(
+            date_util,
+            'market_data_library_date_util',
+            SimpleNamespace(),
+        )
+        input_date = self.build_utc_datetime(2025, 1, 20, 21, 0, 0, 0)
+
+        res = date_util.get_most_recent_non_weekend_or_today(date=input_date)
+
+        assert res == self.build_utc_datetime(2025, 1, 17, 21, 0, 0, 0)
+
     @pytest.mark.parametrize('input, expected', [
-        (1691107200000, datetime.datetime.utcnow().replace(year=2023, month=8, day=4, hour=0, minute=0, second=0, tzinfo=datetime.timezone.utc))
+        (1691107200000, build_utc_datetime.__func__(2023, 8, 4, 0, 0, 0, 0))
     ])
     def test_parse_utc_timestamp(self, input, expected):
         res = date_util.parse_timestamp(input / 1000)
@@ -78,8 +120,7 @@ class TestDateUtil:
         assert res.tzinfo == expected.tzinfo
 
     @pytest.mark.parametrize('date, format_string, expected', [
-        ('4 Aug, 2023', '%d %b, %Y', datetime.datetime.utcnow().replace(year=2023, month=8, day=4, hour=0, minute=0, second=0,
-                                                   microsecond=0, tzinfo=datetime.timezone.utc),
+        ('4 Aug, 2023', '%d %b, %Y', build_utc_datetime.__func__(2023, 8, 4, 0, 0, 0, 0),
          )
     ])
     def test_parse(self, date, format_string, expected):


### PR DESCRIPTION
## Summary
- use the shared trading-day helper when available and keep a local NYSE-calendar fallback for the current pinned library release
- rework stocks sentiment to anchor on real historical dates instead of weekend-padding offsets
- switch the local library override workflow to editable installs, add dependency wiring coverage, and isolate backend unit tests from live shared-library startup

## Validation
- ./scripts/show_market_data_library_source.sh
- PYTHONPATH="$(pwd)" poetry run pytest tests/unit
- verify both dependency modes with the full suite:
  - local-sibling-editable -> 186 passed
  - git-installed-package -> 186 passed