### PR TITLE
Simplify backend CI triggers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,12 @@
 name: Test and build
+concurrency:
+  group: market-data-notification-test-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 permissions:
   contents: read
 on:
   push:
     branches:
-      - feat/*
-      - feature/*
-      - chore/*
       - master
   pull_request:
     branches:


### PR DESCRIPTION
## Summary
- switch backend CI to the standard pull_request + master push trigger model
- keep workflow concurrency, but do not cancel master publishing runs in progress
- remove feature-branch push validation so feature work is validated on pull requests instead of duplicate branch + PR runs

## Validation
- python3 -c "import sys, yaml; yaml.safe_load(open(sys.argv[1]))" .github/workflows/test.yml
- git diff --check