### PR TITLE
Add crypto signal phase 1 backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,10 @@ When the server is running:
 - ReDoc: http://localhost:8080/redoc
 - Health check: `GET /healthz`
 
+In production, only `GET /healthz` and `POST /tradingview/daily-stocks` are
+public. Swagger UI, ReDoc, OpenAPI, and all other routes stay behind
+`X-Api-Auth`.
+
 Important endpoints:
 
 - `POST /tradingview/daily-stocks`

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ FastAPI backend and scheduled job runner for stock and crypto Telegram notificat
 
 - Scheduled Telegram digest with sentiment, sector breadth, and standout-coin context
 - Aggregation across multiple external providers in one notification flow
+- Phase-1 crypto signal history, scoring, and operator-only reporting from stored snapshots
 - Backend-specific orchestration over provider adapters, with unofficial or privacy-sensitive provider contracts expected to come from `market-data-library`
 
 ## What It Does
@@ -65,6 +66,7 @@ flowchart LR
 1. The crypto job fetches data from external providers
 2. The job formats a digest-oriented crypto summary
 3. The backend sends the result to the crypto Telegram channel
+4. The phase-1 signal path persists normalized snapshots and sends a separate private/admin operator digest when enabled
 
 ## Key Paths
 
@@ -76,6 +78,8 @@ src/job/stocks/stocks.py                 Stock notification entry point
 src/job/crypto/crypto.py                 Crypto notification entry point
 src/job/crypto/crypto_digest_message_sender.py
 src/job/crypto/crypto_digest_formatter.py
+src/job/crypto/crypto_signal_report.py   Local crypto signal report entry point
+src/service/crypto_signal/               Crypto signal persistence and scoring
 src/notification_destination/telegram_notification.py
 src/config/config.py                     Environment contract
 tests/unit/                              Main unit test surface
@@ -135,6 +139,16 @@ CRYPTO_TELEGRAM_DEV_BOT_TOKEN=...
 CRYPTO_TELEGRAM_DEV_ID=...
 # Used by the optional manual CryptoQuant `price-ohlcv` route.
 CRYPTOQUANT_API_TOKEN=...
+
+CRYPTO_SIGNAL_DB_PATH=var/crypto_signal/crypto_signal.sqlite3
+# Optional test-mode override. Defaults to var/crypto_signal/crypto_signal.test.sqlite3.
+CRYPTO_SIGNAL_TEST_DB_PATH=var/crypto_signal/crypto_signal.test.sqlite3
+# Optional private/operator signal recipient. Defaults to CRYPTO_TELEGRAM_ADMIN_ID.
+CRYPTO_SIGNAL_RECIPIENT_ID=...
+CRYPTO_SIGNAL_TRACKED_UNIVERSE=BTC,ETH,SOL
+CRYPTO_SIGNAL_WATCHLIST=
+CRYPTO_SIGNAL_DYNAMIC_CANDIDATE_MIN_PRICE_USD=0
+CRYPTO_SIGNAL_DYNAMIC_CANDIDATE_MIN_VOLUME_24H=50000000
 
 API_AUTH_TOKEN=...
 TRADING_VIEW_WEBHOOK_SECRET=...
@@ -205,6 +219,29 @@ If you invoke the job files directly instead of using `python -m`, add the repo 
 PYTHONPATH="$(pwd)" ENV=dev poetry run python src/job/stocks/stocks.py --force_run=1 --test_mode=1
 PYTHONPATH="$(pwd)" ENV=dev poetry run python src/job/crypto/crypto.py --force_run=1 --test_mode=1
 ```
+
+### Crypto Signal Phase 1
+
+The crypto signal feature keeps the public crypto digest unchanged while adding
+SQLite-backed history, deterministic scoring, and a separate operator-only
+signal digest. Phase 1 must stay on private/admin routing; the signal path
+rejects `CRYPTO_TELEGRAM_CHANNEL_ID` as a destination.
+
+Render the latest stored signal report without sending Telegram:
+
+```bash
+ENV=dev PYTHONPATH="$(pwd)" poetry run python src/job/crypto/crypto_signal_report.py --window 7d --limit 3 --send_telegram=0 --test_mode=1
+```
+
+Send the rendered report only after confirming the configured signal recipient
+is private:
+
+```bash
+ENV=dev PYTHONPATH="$(pwd)" poetry run python src/job/crypto/crypto_signal_report.py --window 7d --limit 3 --send_telegram=1 --test_mode=1
+```
+
+For the full operator procedure, see the workspace runbook:
+https://github.com/hanchiang/market-data-workspace/blob/master/docs/runbooks/crypto-signal-phase-1.md
 
 ### Option 2: Docker
 

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -333,6 +333,78 @@ def get_cryptoquant_api_token() -> str:
 def has_cryptoquant_api_token() -> bool:
     return bool(get_cryptoquant_api_token().strip())
 
+_DEFAULT_CRYPTO_SIGNAL_WATCHLIST_IDS = {
+    'BTC': 1,
+    'ETH': 1027,
+    'SOL': 5426,
+}
+
+
+def get_crypto_signal_db_path() -> str:
+    return os.getenv(
+        'CRYPTO_SIGNAL_DB_PATH',
+        'var/crypto_signal/crypto_signal.sqlite3',
+    )
+
+
+def get_crypto_signal_recipient_id() -> str:
+    return os.getenv(
+        'CRYPTO_SIGNAL_RECIPIENT_ID',
+        get_telegram_crypto_admin_id(),
+    )
+
+
+def get_crypto_signal_tracked_universe() -> list[tuple[str, int]]:
+    return _parse_crypto_signal_coin_entries(
+        env_name='CRYPTO_SIGNAL_TRACKED_UNIVERSE',
+        default_raw_value='BTC,ETH,SOL',
+    )
+
+
+def get_crypto_signal_watchlist() -> list[tuple[str, int]]:
+    return _parse_crypto_signal_coin_entries(
+        env_name='CRYPTO_SIGNAL_WATCHLIST',
+        default_raw_value='',
+    )
+
+
+def _parse_crypto_signal_coin_entries(
+    env_name: str,
+    default_raw_value: str,
+) -> list[tuple[str, int]]:
+    raw_value = os.getenv(env_name, default_raw_value)
+    entries = []
+    for raw_entry in raw_value.split(','):
+        entry = raw_entry.strip()
+        if entry == '':
+            continue
+
+        if ':' in entry:
+            symbol, raw_coin_id = entry.split(':', 1)
+            symbol = symbol.strip().upper()
+            raw_coin_id = raw_coin_id.strip()
+            if symbol == '' or raw_coin_id == '':
+                raise RuntimeError(
+                    f'{env_name} entries must look like SYMBOL or SYMBOL:ID'
+                )
+            try:
+                coin_id = int(raw_coin_id)
+            except ValueError as error:
+                raise RuntimeError(
+                    f'{env_name} coin ids must be integers'
+                ) from error
+        else:
+            symbol = entry.upper()
+            if symbol not in _DEFAULT_CRYPTO_SIGNAL_WATCHLIST_IDS:
+                raise RuntimeError(
+                    f'{env_name} unqualified symbols must use a '
+                    'known default id or the SYMBOL:ID form'
+                )
+            coin_id = _DEFAULT_CRYPTO_SIGNAL_WATCHLIST_IDS[symbol]
+
+        entries.append((symbol, coin_id))
+    return entries
+
 def get_should_send_stocks_sentiment_message():
     return os.getenv('SHOULD_SEND_STOCKS_SENTIMENT_MESSAGE', 'true') == 'true'
 

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -129,7 +129,11 @@ def get_whitelist_ips():
     return os.getenv('WHITELIST_IPS', '').split(',')
 
 def get_auth_exclude_endpoints() -> List[str]:
-    return os.getenv('AUTH_EXCLUDE_ENDPOINTS', '').split(',')
+    return [
+        endpoint.strip()
+        for endpoint in os.getenv('AUTH_EXCLUDE_ENDPOINTS', '').split(',')
+        if endpoint.strip()
+    ]
 
 def get_api_auth_token():
     if not os.getenv('API_AUTH_TOKEN', None):

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1,9 +1,10 @@
 import os
+from pathlib import Path
 from typing import Tuple, List
 from urllib.parse import urlparse
 
 from dotenv import load_dotenv
-from src.runtime.runtime_mode import DEFAULT_RUNTIME_MODE
+from src.runtime.runtime_mode import DEFAULT_RUNTIME_MODE, RuntimeMode
 
 load_dotenv()
 
@@ -340,10 +341,23 @@ _DEFAULT_CRYPTO_SIGNAL_WATCHLIST_IDS = {
 }
 
 
-def get_crypto_signal_db_path() -> str:
-    return os.getenv(
+def get_crypto_signal_db_path(
+    runtime_mode: RuntimeMode | None = None,
+) -> str:
+    prod_db_path = os.getenv(
         'CRYPTO_SIGNAL_DB_PATH',
         'var/crypto_signal/crypto_signal.sqlite3',
+    )
+    active_runtime_mode = (
+        DEFAULT_RUNTIME_MODE if runtime_mode is None else runtime_mode
+    )
+    # Keep test-mode history isolated so local replay does not contaminate the
+    # operator-facing store used by normal runs.
+    if not active_runtime_mode.is_test_mode:
+        return prod_db_path
+    return os.getenv(
+        'CRYPTO_SIGNAL_TEST_DB_PATH',
+        _build_test_crypto_signal_db_path(prod_db_path),
     )
 
 
@@ -365,6 +379,29 @@ def get_crypto_signal_watchlist() -> list[tuple[str, int]]:
     return _parse_crypto_signal_coin_entries(
         env_name='CRYPTO_SIGNAL_WATCHLIST',
         default_raw_value='',
+    )
+
+
+def get_crypto_signal_dynamic_candidate_min_price_usd() -> float:
+    # Token price is a weak proxy for tradability because supply design can
+    # make legitimate projects look artificially "cheap". Keep the default at
+    # zero and rely on the separate volume floor unless an operator explicitly
+    # wants a stricter price-based presentation filter.
+    return _get_positive_float_env(
+        env_name='CRYPTO_SIGNAL_DYNAMIC_CANDIDATE_MIN_PRICE_USD',
+        default_raw_value='0',
+        allow_zero=True,
+    )
+
+
+def get_crypto_signal_dynamic_candidate_min_volume_24h() -> float:
+    # This floor only affects operator ranking for dynamic candidates. Stored
+    # history remains broader so later analysis is not forced through the same
+    # presentation threshold.
+    return _get_positive_float_env(
+        env_name='CRYPTO_SIGNAL_DYNAMIC_CANDIDATE_MIN_VOLUME_24H',
+        default_raw_value='50000000',
+        allow_zero=True,
     )
 
 
@@ -404,6 +441,32 @@ def _parse_crypto_signal_coin_entries(
 
         entries.append((symbol, coin_id))
     return entries
+
+
+def _build_test_crypto_signal_db_path(prod_db_path: str) -> str:
+    path = Path(prod_db_path)
+    if path.suffix == '':
+        return f'{prod_db_path}.test'
+    return str(path.with_name(f'{path.stem}.test{path.suffix}'))
+
+
+def _get_positive_float_env(
+    env_name: str,
+    default_raw_value: str,
+    allow_zero: bool = False,
+) -> float:
+    raw_value = os.getenv(env_name, default_raw_value)
+    try:
+        parsed_value = float(raw_value)
+    except ValueError as error:
+        raise RuntimeError(f'{env_name} must be a positive number') from error
+
+    if allow_zero:
+        if parsed_value < 0:
+            raise RuntimeError(f'{env_name} must be a positive number')
+    elif parsed_value <= 0:
+        raise RuntimeError(f'{env_name} must be a positive number')
+    return parsed_value
 
 def get_should_send_stocks_sentiment_message():
     return os.getenv('SHOULD_SEND_STOCKS_SENTIMENT_MESSAGE', 'true') == 'true'

--- a/src/data_source/market_data_library.py
+++ b/src/data_source/market_data_library.py
@@ -38,3 +38,28 @@ def init_market_data_api() -> None:
             tradfi_api_kwargs['server_host'] = selenium_server_host
 
         tradfi_api = TradFiAPI(**tradfi_api_kwargs)
+
+
+async def cleanup_market_data_api() -> None:
+    global crypto_api
+    global tradfi_api
+
+    if crypto_api is not None:
+        await crypto_api.cmc.cmc_service.cleanup()
+        await crypto_api.alternativeme.alternativeme_service.cleanup()
+        cryptoquant_service = crypto_api.cryptoquant.cryptoquant_service
+        if cryptoquant_service is not None:
+            await cryptoquant_service.cleanup()
+
+    if tradfi_api is not None:
+        await tradfi_api.barchart.barchart_stocks.cleanup()
+        await tradfi_api.barchart.barchart_options.cleanup()
+
+    reset_market_data_api()
+
+
+def reset_market_data_api() -> None:
+    global crypto_api
+    global tradfi_api
+    crypto_api = None
+    tradfi_api = None

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -10,6 +10,7 @@ from src.http_client import HttpClient
 from src.third_party_service.barchart import ThirdPartyBarchartService
 from src.third_party_service.vix_central import ThirdPartyVixCentralService
 from src.service.vix_central import VixCentralService
+from src.data_source.market_data_library import cleanup_market_data_api
 
 logger = logging.getLogger('Dependencies')
 class Dependencies:
@@ -55,12 +56,20 @@ class Dependencies:
 
   @staticmethod
   async def cleanup():
-    await Dependencies.vix_central_service.cleanup()
-    await Dependencies.barchart_service.cleanup()
-    if Dependencies.cryptoquant_api_service is not None:
-      service = Dependencies.cryptoquant_api_service.cryptoquant_service
-      if service is not None:
-        await service.cleanup()
+    if Dependencies.vix_central_service is not None:
+      await Dependencies.vix_central_service.cleanup()
+    await cleanup_market_data_api()
+
+    Dependencies.is_initialised = False
+    Dependencies.tradingview_service = None
+    Dependencies.thirdparty_vix_central_service = None
+    Dependencies.vix_central_service = None
+    Dependencies.thirdparty_barchart_service = None
+    Dependencies.barchart_service = None
+    Dependencies.stocks_sentiment_service = None
+    Dependencies.cryptoquant_api_service = None
+    Dependencies.crypto_sentiment_service = None
+    Dependencies.crypto_stats_service = None
 
   # stocks
   @staticmethod

--- a/src/job/crypto/crypto.py
+++ b/src/job/crypto/crypto.py
@@ -2,6 +2,9 @@ import asyncio
 import logging
 
 from src.job.crypto.crypto_digest_message_sender import CryptoDigestMessageSender
+from src.job.crypto.crypto_signal_digest_message_sender import (
+    CryptoSignalDigestMessageSender,
+)
 from src.job.job_wrapper import JobWrapper
 from src.config import config
 from src.runtime.runtime_mode import RuntimeMode
@@ -47,6 +50,7 @@ class CryptoNotificationJob(JobWrapper):
     def message_senders(self):
         return [
             CryptoDigestMessageSender(runtime_mode=self.runtime_mode),
+            CryptoSignalDigestMessageSender(runtime_mode=self.runtime_mode),
         ]
 
     @property

--- a/src/job/crypto/crypto.py
+++ b/src/job/crypto/crypto.py
@@ -57,7 +57,16 @@ class CryptoNotificationJob(JobWrapper):
     def market_data_type(self):
         return MarketDataType.CRYPTO
 
-# ENV=dev poetry run python src/job/crypto/crypto.py --force_run=1 --test_mode=1
+# Usage:
+# - Full local test path, including public digest formatting, SQLite signal
+#   snapshot persistence, and private/admin signal routing:
+#   ENV=dev PYTHONPATH="$(pwd)" poetry run python src/job/crypto/crypto.py --force_run=1 --test_mode=1
+# - Production-runtime smoke without Telegram delivery:
+#   DISABLE_TELEGRAM=true ENV=dev PYTHONPATH="$(pwd)" poetry run python src/job/crypto/crypto.py --force_run=1
+#
+# Phase-1 crypto signal output must stay on private/admin routing. The signal
+# sender reads CRYPTO_SIGNAL_RECIPIENT_ID, falling back to CRYPTO_TELEGRAM_ADMIN_ID,
+# and rejects CRYPTO_TELEGRAM_CHANNEL_ID as an invalid destination.
 if __name__ == '__main__':
     loop = asyncio.get_event_loop()
     job = CryptoNotificationJob()

--- a/src/job/crypto/crypto_digest_message_sender.py
+++ b/src/job/crypto/crypto_digest_message_sender.py
@@ -188,6 +188,7 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
         )
 
         try:
+            repository.init_schema()
             observation_counts = repository.get_coin_observation_counts_since(
                 coin_ids=[coin_id for _symbol, coin_id in persisted_entries],
                 start_timestamp_utc=history_start_utc,

--- a/src/job/crypto/crypto_digest_message_sender.py
+++ b/src/job/crypto/crypto_digest_message_sender.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional
 
 from market_data_library.types import cmc_type
 
+from src.config import config
 from src.dependencies import Dependencies
 from src.job.crypto.crypto_digest_formatter import (
     build_digest_message,
@@ -12,8 +13,14 @@ from src.job.crypto.crypto_digest_formatter import (
     should_emit_sector_detail_message,
 )
 from src.job.message_sender_wrapper import MessageSenderWrapper
+from src.notification_destination.telegram_notification import send_message_to_admin
+from src.runtime.runtime_mode import DEFAULT_RUNTIME_MODE
+from src.service.crypto_signal.repository import CryptoSignalRepository
+from src.service.crypto_signal.snapshot_builder import build_snapshot
 from src.type.market_data_type import MarketDataType
 from src.util.date_util import get_current_datetime
+from src.util.exception import get_exception_message
+from src.util.my_telegram import format_messages_to_telegram
 
 
 logger = logging.getLogger('Crypto digest message sender')
@@ -24,6 +31,9 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
         super().__init__(runtime_mode=runtime_mode)
         self.cmc_service = Dependencies.get_crypto_stats_service()
         self.sentiment_service = Dependencies.get_crypto_sentiment_service()
+        self.signal_repository = CryptoSignalRepository()
+        self.tracked_universe_entries = config.get_crypto_signal_tracked_universe()
+        self.watchlist_entries = config.get_crypto_signal_watchlist()
 
     @property
     def data_source(self):
@@ -53,6 +63,26 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
             weakest_sector=weakest_sector,
             sector_details=sector_details,
         )
+        tracked_universe_coin_details = await self._load_tracked_universe_coin_details()
+
+        persistence_failure_message = self._persist_signal_snapshot(
+            current=current,
+            sentiment=sentiment,
+            strongest_sector=strongest_sector,
+            weakest_sector=weakest_sector,
+            standout_entries=standout_entries,
+            standout_coin_details=standout_coin_details,
+            sector_details=sector_details,
+            sector_detail_coin_details=sector_detail_coin_details,
+            tracked_universe_coin_details=tracked_universe_coin_details,
+        )
+        if persistence_failure_message is not None:
+            await send_message_to_admin(
+                message=format_messages_to_telegram(
+                    [persistence_failure_message]
+                ),
+                market_data_type=MarketDataType.CRYPTO,
+            )
 
         digest_message = build_digest_message(
             current=current,
@@ -65,6 +95,59 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
             sector_detail_coin_details=sector_detail_coin_details,
         )
         return [digest_message]
+
+    def _persist_signal_snapshot(
+        self,
+        current,
+        sentiment,
+        strongest_sector,
+        weakest_sector,
+        standout_entries,
+        standout_coin_details,
+        sector_details,
+        sector_detail_coin_details,
+        tracked_universe_coin_details,
+    ) -> str | None:
+        runtime_mode = getattr(self, 'runtime_mode', DEFAULT_RUNTIME_MODE)
+        repository = getattr(self, 'signal_repository', CryptoSignalRepository())
+        tracked_universe_entries = getattr(
+            self,
+            'tracked_universe_entries',
+            config.get_crypto_signal_tracked_universe(),
+        )
+        watchlist_entries = getattr(
+            self,
+            'watchlist_entries',
+            config.get_crypto_signal_watchlist(),
+        )
+        snapshot = build_snapshot(
+            current=current,
+            runtime_mode=runtime_mode,
+            source_name=self.data_source,
+            sentiment=sentiment,
+            strongest_sector=strongest_sector,
+            weakest_sector=weakest_sector,
+            standout_entries=standout_entries,
+            standout_coin_details=standout_coin_details,
+            sector_details=sector_details,
+            sector_detail_coin_details=sector_detail_coin_details,
+            tracked_universe_entries=self._get_persisted_universe_entries(
+                tracked_universe_entries=tracked_universe_entries,
+                watchlist_entries=watchlist_entries,
+            ),
+            tracked_universe_coin_details=tracked_universe_coin_details,
+            watchlist_entries=watchlist_entries,
+        )
+        try:
+            repository.save_snapshot(snapshot)
+        except Exception as error:
+            logger.exception('Failed to persist crypto signal snapshot')
+            return get_exception_message(
+                error,
+                cls=self.__class__.__name__,
+                should_escape_markdown=True,
+            )
+        return None
 
     async def _load_sector_snapshots(
         self,
@@ -173,3 +256,38 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
                 continue
             coin_details[coin_id] = detail
         return coin_details
+
+    async def _load_tracked_universe_coin_details(self) -> Dict[int, cmc_type.CoinDetail]:
+        tracked_universe_entries = getattr(
+            self,
+            'tracked_universe_entries',
+            config.get_crypto_signal_tracked_universe(),
+        )
+        watchlist_entries = getattr(
+            self,
+            'watchlist_entries',
+            config.get_crypto_signal_watchlist(),
+        )
+        return await self._load_coin_details(
+            coin_ids=[
+                coin_id
+                for _symbol, coin_id in self._get_persisted_universe_entries(
+                    tracked_universe_entries=tracked_universe_entries,
+                    watchlist_entries=watchlist_entries,
+                )
+            ],
+            log_context='tracked universe coin enrichment',
+        )
+
+    @staticmethod
+    def _get_persisted_universe_entries(
+        tracked_universe_entries: List[tuple[str, int]],
+        watchlist_entries: List[tuple[str, int]],
+    ) -> List[tuple[str, int]]:
+        merged_entries = {
+            coin_id: (symbol, coin_id)
+            for symbol, coin_id in tracked_universe_entries
+        }
+        for symbol, coin_id in watchlist_entries:
+            merged_entries.setdefault(coin_id, (symbol, coin_id))
+        return list(merged_entries.values())

--- a/src/job/crypto/crypto_digest_message_sender.py
+++ b/src/job/crypto/crypto_digest_message_sender.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime
 import logging
 from typing import Dict, List, Optional
 
@@ -15,6 +16,7 @@ from src.job.crypto.crypto_digest_formatter import (
 from src.job.message_sender_wrapper import MessageSenderWrapper
 from src.notification_destination.telegram_notification import send_message_to_admin
 from src.runtime.runtime_mode import DEFAULT_RUNTIME_MODE
+from src.service.crypto_signal.backfill import CryptoSignalBackfillService
 from src.service.crypto_signal.repository import CryptoSignalRepository
 from src.service.crypto_signal.snapshot_builder import build_snapshot
 from src.type.market_data_type import MarketDataType
@@ -24,6 +26,7 @@ from src.util.my_telegram import format_messages_to_telegram
 
 
 logger = logging.getLogger('Crypto digest message sender')
+_SIGNAL_BACKFILL_DAYS = 30
 
 
 class CryptoDigestMessageSender(MessageSenderWrapper):
@@ -31,7 +34,9 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
         super().__init__(runtime_mode=runtime_mode)
         self.cmc_service = Dependencies.get_crypto_stats_service()
         self.sentiment_service = Dependencies.get_crypto_sentiment_service()
-        self.signal_repository = CryptoSignalRepository()
+        self.signal_repository = CryptoSignalRepository(
+            runtime_mode=self.runtime_mode
+        )
         self.tracked_universe_entries = config.get_crypto_signal_tracked_universe()
         self.watchlist_entries = config.get_crypto_signal_watchlist()
 
@@ -65,8 +70,9 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
         )
         tracked_universe_coin_details = await self._load_tracked_universe_coin_details()
 
-        persistence_failure_message = self._persist_signal_snapshot(
+        snapshot = self._build_signal_snapshot(
             current=current,
+            runtime_mode=getattr(self, 'runtime_mode', DEFAULT_RUNTIME_MODE),
             sentiment=sentiment,
             strongest_sector=strongest_sector,
             weakest_sector=weakest_sector,
@@ -76,6 +82,11 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
             sector_detail_coin_details=sector_detail_coin_details,
             tracked_universe_coin_details=tracked_universe_coin_details,
         )
+        await self._backfill_signal_history(
+            current=current,
+            snapshot=snapshot,
+        )
+        persistence_failure_message = self._persist_signal_snapshot(snapshot=snapshot)
         if persistence_failure_message is not None:
             await send_message_to_admin(
                 message=format_messages_to_telegram(
@@ -96,9 +107,10 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
         )
         return [digest_message]
 
-    def _persist_signal_snapshot(
+    def _build_signal_snapshot(
         self,
         current,
+        runtime_mode,
         sentiment,
         strongest_sector,
         weakest_sector,
@@ -107,9 +119,7 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
         sector_details,
         sector_detail_coin_details,
         tracked_universe_coin_details,
-    ) -> str | None:
-        runtime_mode = getattr(self, 'runtime_mode', DEFAULT_RUNTIME_MODE)
-        repository = getattr(self, 'signal_repository', CryptoSignalRepository())
+    ):
         tracked_universe_entries = getattr(
             self,
             'tracked_universe_entries',
@@ -120,7 +130,7 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
             'watchlist_entries',
             config.get_crypto_signal_watchlist(),
         )
-        snapshot = build_snapshot(
+        return build_snapshot(
             current=current,
             runtime_mode=runtime_mode,
             source_name=self.data_source,
@@ -138,6 +148,85 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
             tracked_universe_coin_details=tracked_universe_coin_details,
             watchlist_entries=watchlist_entries,
         )
+
+    async def _backfill_signal_history(
+        self,
+        current,
+        snapshot,
+    ) -> None:
+        repository = getattr(
+            self,
+            'signal_repository',
+            CryptoSignalRepository(runtime_mode=self.runtime_mode),
+        )
+        backfill_service = getattr(
+            self,
+            'signal_backfill_service',
+            CryptoSignalBackfillService(cmc_service=self.cmc_service),
+        )
+        tracked_universe_entries = getattr(
+            self,
+            'tracked_universe_entries',
+            config.get_crypto_signal_tracked_universe(),
+        )
+        watchlist_entries = getattr(
+            self,
+            'watchlist_entries',
+            config.get_crypto_signal_watchlist(),
+        )
+        current_timestamp_utc = current.astimezone(datetime.timezone.utc)
+        persisted_entries = self._build_backfill_entries(
+            snapshot=snapshot,
+            tracked_universe_entries=tracked_universe_entries,
+            watchlist_entries=watchlist_entries,
+        )
+        if len(persisted_entries) == 0:
+            return
+
+        history_start_utc = current_timestamp_utc - datetime.timedelta(
+            days=_SIGNAL_BACKFILL_DAYS
+        )
+
+        try:
+            observation_counts = repository.get_coin_observation_counts_since(
+                coin_ids=[coin_id for _symbol, coin_id in persisted_entries],
+                start_timestamp_utc=history_start_utc,
+            )
+            # Only bootstrap coins with no retained observations yet. Once a coin
+            # has entered the store, future runs should extend it forward rather
+            # than re-requesting and re-merging the whole historical window.
+            missing_entries = [
+                entry
+                for entry in persisted_entries
+                if observation_counts.get(entry[1], 0) == 0
+            ]
+            if len(missing_entries) == 0:
+                return
+
+            # Bootstrap before the live snapshot write so first-seen coins can
+            # immediately score against retained history in the same run.
+            backfill_snapshots = await backfill_service.build_snapshots(
+                coin_entries=missing_entries,
+                watchlist_coin_ids={coin_id for _symbol, coin_id in watchlist_entries},
+                current_timestamp_utc=current_timestamp_utc,
+                days=_SIGNAL_BACKFILL_DAYS,
+            )
+            for backfill_snapshot in backfill_snapshots:
+                repository.save_or_merge_snapshot(backfill_snapshot)
+        except Exception:
+            logger.exception(
+                'Crypto signal backfill failed; continuing with live snapshot only'
+            )
+
+    def _persist_signal_snapshot(
+        self,
+        snapshot,
+    ) -> str | None:
+        repository = getattr(
+            self,
+            'signal_repository',
+            CryptoSignalRepository(runtime_mode=self.runtime_mode),
+        )
         try:
             repository.save_snapshot(snapshot)
         except Exception as error:
@@ -148,6 +237,25 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
                 should_escape_markdown=True,
             )
         return None
+
+    def _build_backfill_entries(
+        self,
+        snapshot,
+        tracked_universe_entries,
+        watchlist_entries,
+    ) -> list[tuple[str, int]]:
+        ordered_entries: dict[int, tuple[str, int]] = {}
+        # Seed bootstrap coverage from the configured persistence universe, then
+        # extend it with whatever the live snapshot surfaced without duplicating
+        # coin ids across those sources.
+        for symbol, coin_id in self._get_persisted_universe_entries(
+            tracked_universe_entries=tracked_universe_entries,
+            watchlist_entries=watchlist_entries,
+        ):
+            ordered_entries.setdefault(coin_id, (symbol, coin_id))
+        for coin in snapshot.coins:
+            ordered_entries.setdefault(coin.coin_id, (coin.symbol, coin.coin_id))
+        return list(ordered_entries.values())
 
     async def _load_sector_snapshots(
         self,

--- a/src/job/crypto/crypto_signal_digest_message_sender.py
+++ b/src/job/crypto/crypto_signal_digest_message_sender.py
@@ -25,8 +25,11 @@ _SNAPSHOT_FRESHNESS_THRESHOLD = datetime.timedelta(minutes=90)
 class CryptoSignalDigestMessageSender(MessageSenderWrapper):
     def __init__(self, runtime_mode=None):
         super().__init__(runtime_mode=runtime_mode)
-        self.signal_repository = CryptoSignalRepository()
+        self.signal_repository = CryptoSignalRepository(
+            runtime_mode=self.runtime_mode
+        )
         self.watchlist_entries = config.get_crypto_signal_watchlist()
+        self.tracked_universe_entries = config.get_crypto_signal_tracked_universe()
 
     @property
     def data_source(self):
@@ -66,11 +69,18 @@ class CryptoSignalDigestMessageSender(MessageSenderWrapper):
             return None
 
     async def format_message(self) -> List[str]:
-        repository = getattr(self, 'signal_repository', CryptoSignalRepository())
+        repository = getattr(
+            self,
+            'signal_repository',
+            CryptoSignalRepository(runtime_mode=self.runtime_mode),
+        )
         latest_snapshot = repository.get_latest_snapshot()
         if latest_snapshot is None:
             return []
 
+        # The scheduled operator digest should not replay old signals long
+        # after the source crypto job ran; the local CLI report remains the
+        # explicit path for reviewing older retained history.
         if not self._is_fresh_enough(latest_snapshot.run.run_timestamp_utc):
             return []
 
@@ -82,8 +92,18 @@ class CryptoSignalDigestMessageSender(MessageSenderWrapper):
             latest_snapshot=latest_snapshot,
             history=history,
             watchlist_coin_ids={coin_id for _symbol, coin_id in self.watchlist_entries},
+            tracked_universe_coin_ids={
+                coin_id
+                for _symbol, coin_id in getattr(
+                    self,
+                    'tracked_universe_entries',
+                    config.get_crypto_signal_tracked_universe(),
+                )
+            },
             window_label=window_label,
             limit=3,
+            min_dynamic_price_usd=config.get_crypto_signal_dynamic_candidate_min_price_usd(),
+            min_dynamic_volume_24h=config.get_crypto_signal_dynamic_candidate_min_volume_24h(),
         )
         return [build_crypto_signal_message(view)]
 

--- a/src/job/crypto/crypto_signal_digest_message_sender.py
+++ b/src/job/crypto/crypto_signal_digest_message_sender.py
@@ -1,0 +1,97 @@
+import datetime
+import logging
+from typing import List
+
+from src.config import config
+from src.job.crypto.crypto_signal_formatter import build_crypto_signal_message
+from src.job.message_sender_wrapper import MessageSenderWrapper
+from src.notification_destination.telegram_notification import (
+    send_crypto_signal_message,
+    send_message_to_admin,
+)
+from src.runtime.runtime_mode import DEFAULT_RUNTIME_MODE
+from src.service.crypto_signal.repository import CryptoSignalRepository
+from src.service.crypto_signal.scorer import build_digest_view, get_window_start
+from src.type.market_data_type import MarketDataType
+from src.util.date_util import get_current_datetime
+from src.util.exception import get_exception_message
+from src.util.my_telegram import format_messages_to_telegram
+
+
+logger = logging.getLogger('Crypto signal digest message sender')
+_SNAPSHOT_FRESHNESS_THRESHOLD = datetime.timedelta(minutes=90)
+
+
+class CryptoSignalDigestMessageSender(MessageSenderWrapper):
+    def __init__(self, runtime_mode=None):
+        super().__init__(runtime_mode=runtime_mode)
+        self.signal_repository = CryptoSignalRepository()
+        self.watchlist_entries = config.get_crypto_signal_watchlist()
+
+    @property
+    def data_source(self):
+        return 'SQLite + heuristic scorer'
+
+    @property
+    def market_data_type(self):
+        return MarketDataType.CRYPTO
+
+    async def start(self):
+        try:
+            messages = await self.format_message()
+            if messages is None or len(messages) == 0:
+                logger.info('Skipping crypto signal send because no fresh snapshot was available')
+                return None
+
+            telegram_message = format_messages_to_telegram(messages)
+            return await send_crypto_signal_message(
+                message=telegram_message,
+                chat_id=config.get_crypto_signal_recipient_id(),
+                runtime_mode=self.runtime_mode,
+            )
+        except Exception as error:
+            logger.error(get_exception_message(error, cls=self.__class__.__name__))
+            await send_message_to_admin(
+                message=format_messages_to_telegram(
+                    [
+                        get_exception_message(
+                            error,
+                            cls=self.__class__.__name__,
+                            should_escape_markdown=True,
+                        )
+                    ]
+                ),
+                market_data_type=MarketDataType.CRYPTO,
+            )
+            return None
+
+    async def format_message(self) -> List[str]:
+        repository = getattr(self, 'signal_repository', CryptoSignalRepository())
+        latest_snapshot = repository.get_latest_snapshot()
+        if latest_snapshot is None:
+            return []
+
+        if not self._is_fresh_enough(latest_snapshot.run.run_timestamp_utc):
+            return []
+
+        window_label = '7d'
+        history = repository.get_snapshots_since(
+            get_window_start(latest_snapshot, window_label=window_label)
+        )
+        view = build_digest_view(
+            latest_snapshot=latest_snapshot,
+            history=history,
+            watchlist_coin_ids={coin_id for _symbol, coin_id in self.watchlist_entries},
+            window_label=window_label,
+            limit=3,
+        )
+        return [build_crypto_signal_message(view)]
+
+    def _is_fresh_enough(self, run_timestamp_utc: datetime.datetime) -> bool:
+        runtime_mode = getattr(self, 'runtime_mode', DEFAULT_RUNTIME_MODE)
+        if runtime_mode.bypass_schedule:
+            return True
+
+        now_utc = get_current_datetime().astimezone(datetime.timezone.utc)
+        age = now_utc - run_timestamp_utc.astimezone(datetime.timezone.utc)
+        return age <= _SNAPSHOT_FRESHNESS_THRESHOLD

--- a/src/job/crypto/crypto_signal_formatter.py
+++ b/src/job/crypto/crypto_signal_formatter.py
@@ -22,17 +22,19 @@ def build_crypto_signal_message(view: CryptoSignalDigestView) -> str:
     ]
     lines.extend(
         _format_candidate_section(
-            title='Strong momentum',
+            title=f'Strong {view.window_label} momentum',
             candidates=view.strong_candidates,
             empty_text='No strong candidates met the current threshold.',
+            window_label=view.window_label,
         )
     )
     lines.append('')
     lines.extend(
         _format_candidate_section(
-            title='Weak momentum',
+            title=f'Weak {view.window_label} momentum',
             candidates=view.weak_candidates,
             empty_text='No weak candidates met the current threshold.',
+            window_label=view.window_label,
         )
     )
     lines.append('')
@@ -41,6 +43,7 @@ def build_crypto_signal_message(view: CryptoSignalDigestView) -> str:
             title='Watchlist',
             candidates=view.watchlist_candidates,
             empty_text='No watchlist candidates were available for this window.',
+            window_label=view.window_label,
         )
     )
     return '\n'.join(lines).strip()
@@ -50,6 +53,7 @@ def _format_candidate_section(
     title: str,
     candidates: list[CryptoSignalCandidate],
     empty_text: str,
+    window_label: str,
 ) -> list[str]:
     lines = [f'*{escape_markdown(title)}*']
     if len(candidates) == 0:
@@ -57,13 +61,17 @@ def _format_candidate_section(
         return lines
 
     for candidate in candidates:
-        lines.append(_format_candidate(candidate))
+        lines.append(_format_candidate(candidate, window_label=window_label))
     return lines
 
 
-def _format_candidate(candidate: CryptoSignalCandidate) -> str:
+def _format_candidate(
+    candidate: CryptoSignalCandidate,
+    window_label: str,
+) -> str:
     metric_parts = [
         f"score {_format_signed_int(candidate.score)}",
+        f"{window_label} {_format_signed_float(candidate.window_price_change_pct)}",
         f"24h {_format_signed_float(candidate.latest_price_change_24h)}",
         f"obs {candidate.observation_count}",
     ]

--- a/src/job/crypto/crypto_signal_formatter.py
+++ b/src/job/crypto/crypto_signal_formatter.py
@@ -1,0 +1,110 @@
+from src.service.crypto_signal.models import (
+    CryptoSignalCandidate,
+    CryptoSignalDigestView,
+)
+from src.util.my_telegram import escape_markdown
+
+
+def build_crypto_signal_message(view: CryptoSignalDigestView) -> str:
+    run_timestamp = view.latest_snapshot.run.run_timestamp_utc.strftime(
+        '%Y-%m-%d %H:%M UTC'
+    )
+    lines = [
+        '*Crypto trend signal*',
+        f'Run: {escape_markdown(run_timestamp)}',
+        f'Window: {escape_markdown(view.window_label)}',
+        (
+            'Market regime: '
+            f"*{escape_markdown(view.market_regime_label)}*"
+            f" \\({escape_markdown(view.market_regime_reason)}\\)"
+        ),
+        '',
+    ]
+    lines.extend(
+        _format_candidate_section(
+            title='Strong momentum',
+            candidates=view.strong_candidates,
+            empty_text='No strong candidates met the current threshold.',
+        )
+    )
+    lines.append('')
+    lines.extend(
+        _format_candidate_section(
+            title='Weak momentum',
+            candidates=view.weak_candidates,
+            empty_text='No weak candidates met the current threshold.',
+        )
+    )
+    lines.append('')
+    lines.extend(
+        _format_candidate_section(
+            title='Watchlist',
+            candidates=view.watchlist_candidates,
+            empty_text='No watchlist candidates were available for this window.',
+        )
+    )
+    return '\n'.join(lines).strip()
+
+
+def _format_candidate_section(
+    title: str,
+    candidates: list[CryptoSignalCandidate],
+    empty_text: str,
+) -> list[str]:
+    lines = [f'*{escape_markdown(title)}*']
+    if len(candidates) == 0:
+        lines.append(escape_markdown(empty_text))
+        return lines
+
+    for candidate in candidates:
+        lines.append(_format_candidate(candidate))
+    return lines
+
+
+def _format_candidate(candidate: CryptoSignalCandidate) -> str:
+    metric_parts = [
+        f"score {_format_signed_int(candidate.score)}",
+        f"24h {_format_signed_float(candidate.latest_price_change_24h)}",
+        f"obs {candidate.observation_count}",
+    ]
+    if candidate.latest_price_usd is not None:
+        metric_parts.append(f"price {escape_markdown(_format_price(candidate.latest_price_usd))}")
+    if candidate.latest_volume_change_pct_24h is not None:
+        metric_parts.append(
+            'vol chg '
+            f"{_format_signed_float(candidate.latest_volume_change_pct_24h)}"
+        )
+
+    line = (
+        f"• *{escape_markdown(candidate.name)}* "
+        f"{escape_markdown(candidate.symbol)}"
+        f": {', '.join(metric_parts)}"
+    )
+    if len(candidate.reason_tags) > 0:
+        line += (
+            ', reasons '
+            f"{escape_markdown(', '.join(candidate.reason_tags))}"
+        )
+    return line
+
+
+def _format_price(value: float) -> str:
+    if value >= 1000:
+        return f'{value:,.2f}'
+    if value >= 1:
+        return f'{value:.2f}'
+    if value >= 0.01:
+        return f'{value:.4f}'
+    if value >= 0.0001:
+        return f'{value:.6f}'
+    return f'{value:.8f}'
+
+
+def _format_signed_float(value: float | None) -> str:
+    if value is None:
+        return 'n/a'
+    return escape_markdown(f'{value:+.2f}%')
+
+
+def _format_signed_int(value: int) -> str:
+    return escape_markdown(f'{value:+d}')

--- a/src/job/crypto/crypto_signal_report.py
+++ b/src/job/crypto/crypto_signal_report.py
@@ -25,7 +25,7 @@ async def main() -> None:
     args = parser.parse_args()
 
     runtime_mode = RuntimeMode.from_test_mode(args.test_mode == 1)
-    repository = CryptoSignalRepository()
+    repository = CryptoSignalRepository(runtime_mode=runtime_mode)
     latest_snapshot = repository.get_latest_snapshot()
     if latest_snapshot is None:
         logger.info('No crypto signal snapshots are available')
@@ -37,12 +37,18 @@ async def main() -> None:
     watchlist_coin_ids = {
         coin_id for _symbol, coin_id in config.get_crypto_signal_watchlist()
     }
+    tracked_universe_coin_ids = {
+        coin_id for _symbol, coin_id in config.get_crypto_signal_tracked_universe()
+    }
     view = build_digest_view(
         latest_snapshot=latest_snapshot,
         history=history,
         watchlist_coin_ids=watchlist_coin_ids,
+        tracked_universe_coin_ids=tracked_universe_coin_ids,
         window_label=args.window,
         limit=args.limit,
+        min_dynamic_price_usd=config.get_crypto_signal_dynamic_candidate_min_price_usd(),
+        min_dynamic_volume_24h=config.get_crypto_signal_dynamic_candidate_min_volume_24h(),
     )
     message = build_crypto_signal_message(view)
     print(message)

--- a/src/job/crypto/crypto_signal_report.py
+++ b/src/job/crypto/crypto_signal_report.py
@@ -17,7 +17,20 @@ logger = logging.getLogger('Crypto signal report')
 
 
 async def main() -> None:
-    parser = argparse.ArgumentParser(description='Render a crypto signal report from SQLite history')
+    parser = argparse.ArgumentParser(
+        description='Render a crypto signal report from SQLite history',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Examples:
+  ENV=dev PYTHONPATH="$(pwd)" poetry run python src/job/crypto/crypto_signal_report.py --window 7d --limit 3 --send_telegram=0 --test_mode=1
+  ENV=dev PYTHONPATH="$(pwd)" poetry run python src/job/crypto/crypto_signal_report.py --window 7d --limit 3 --send_telegram=1 --test_mode=1
+
+Phase-1 safety:
+  Render with --send_telegram=0 first. Only use --send_telegram=1 after
+  confirming CRYPTO_SIGNAL_RECIPIENT_ID or CRYPTO_TELEGRAM_ADMIN_ID is a
+  private/admin recipient, not the public crypto channel.
+""",
+    )
     parser.add_argument('--window', choices=['3d', '7d', '30d'], default='7d')
     parser.add_argument('--limit', type=int, default=3)
     parser.add_argument('--send_telegram', type=int, choices=[0, 1], default=0)
@@ -64,4 +77,9 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
+    # Usage:
+    # - Inspect stored history without hitting live providers or sending Telegram:
+    #   ENV=dev PYTHONPATH="$(pwd)" poetry run python src/job/crypto/crypto_signal_report.py --window 7d --limit 3 --send_telegram=0 --test_mode=1
+    # - Send the same rendered report to the private/admin signal recipient:
+    #   ENV=dev PYTHONPATH="$(pwd)" poetry run python src/job/crypto/crypto_signal_report.py --window 7d --limit 3 --send_telegram=1 --test_mode=1
     asyncio.run(main())

--- a/src/job/crypto/crypto_signal_report.py
+++ b/src/job/crypto/crypto_signal_report.py
@@ -1,0 +1,61 @@
+import argparse
+import asyncio
+import logging
+
+from src.config import config
+from src.job.crypto.crypto_signal_formatter import build_crypto_signal_message
+from src.notification_destination.telegram_notification import (
+    init_telegram_bots,
+    send_crypto_signal_message,
+)
+from src.runtime.runtime_mode import RuntimeMode
+from src.service.crypto_signal.repository import CryptoSignalRepository
+from src.service.crypto_signal.scorer import build_digest_view, get_window_start
+
+
+logger = logging.getLogger('Crypto signal report')
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description='Render a crypto signal report from SQLite history')
+    parser.add_argument('--window', choices=['3d', '7d', '30d'], default='7d')
+    parser.add_argument('--limit', type=int, default=3)
+    parser.add_argument('--send_telegram', type=int, choices=[0, 1], default=0)
+    parser.add_argument('--test_mode', type=int, choices=[0, 1], default=0)
+    args = parser.parse_args()
+
+    runtime_mode = RuntimeMode.from_test_mode(args.test_mode == 1)
+    repository = CryptoSignalRepository()
+    latest_snapshot = repository.get_latest_snapshot()
+    if latest_snapshot is None:
+        logger.info('No crypto signal snapshots are available')
+        return
+
+    history = repository.get_snapshots_since(
+        get_window_start(latest_snapshot, window_label=args.window)
+    )
+    watchlist_coin_ids = {
+        coin_id for _symbol, coin_id in config.get_crypto_signal_watchlist()
+    }
+    view = build_digest_view(
+        latest_snapshot=latest_snapshot,
+        history=history,
+        watchlist_coin_ids=watchlist_coin_ids,
+        window_label=args.window,
+        limit=args.limit,
+    )
+    message = build_crypto_signal_message(view)
+    print(message)
+    logger.info(message)
+
+    if args.send_telegram == 1:
+        init_telegram_bots()
+        await send_crypto_signal_message(
+            message=message,
+            chat_id=config.get_crypto_signal_recipient_id(),
+            runtime_mode=runtime_mode,
+        )
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/src/notification_destination/telegram_notification.py
+++ b/src/notification_destination/telegram_notification.py
@@ -230,9 +230,8 @@ def _resolve_crypto_signal_target(
     requested_chat_id: str | None,
     runtime_mode: RuntimeMode,
 ):
-    if runtime_mode.use_dev_telegram or config.get_simulate_tradingview_traffic():
-        return crypto_dev_bot, config.get_telegram_crypto_dev_id()
-
+    # Phase 1 signal review stays on the admin/operator path even in test mode;
+    # unlike the public digest, it should not inherit generic dev-channel routing.
     resolved_chat_id = (
         config.get_crypto_signal_recipient_id()
         if requested_chat_id is None
@@ -242,8 +241,6 @@ def _resolve_crypto_signal_target(
         raise RuntimeError(
             'Crypto signal delivery to the public crypto channel is disabled in phase 1'
         )
-    if resolved_chat_id == config.get_telegram_crypto_dev_id():
-        return crypto_dev_bot, resolved_chat_id
     return crypto_admin_bot, resolved_chat_id
 
 

--- a/src/notification_destination/telegram_notification.py
+++ b/src/notification_destination/telegram_notification.py
@@ -168,6 +168,50 @@ async def send_message_to_admin(message: str, market_data_type: MarketDataType):
     print_telegram_message(res)
     return res
 
+
+async def send_crypto_signal_message(
+    message: str,
+    chat_id: str | None = None,
+    runtime_mode: RuntimeMode | None = None,
+):
+    if config.get_disable_telegram():
+        logger.info('Telegram is disabled')
+        return
+
+    active_runtime_mode = (
+        DEFAULT_RUNTIME_MODE if runtime_mode is None else runtime_mode
+    )
+    telegram_client, resolved_chat_id = _resolve_crypto_signal_target(
+        requested_chat_id=chat_id,
+        runtime_mode=active_runtime_mode,
+    )
+
+    try:
+        if len(message) > MAX_TELEGRAM_MESSAGE_LENGTH:
+            res = await _send_split_message_to_channel(
+                telegram_client=telegram_client,
+                chat_id=resolved_chat_id,
+                message=message,
+            )
+        else:
+            res = await telegram_client.send_message(
+                chat_id=resolved_chat_id,
+                text=message,
+                parse_mode='MarkdownV2',
+            )
+        return res
+    except Exception as error:
+        logger.error(get_exception_message(error))
+        fallback_message = _build_telegram_error_alert(
+            context='send_crypto_signal_message',
+            error_text=get_exception_message(error),
+        )
+        return await telegram_client.send_message(
+            chat_id=resolved_chat_id,
+            text=fallback_message,
+            parse_mode='MarkdownV2',
+        )
+
 def get_admin_channel_id_from_market_data_type(market_data_type: MarketDataType):
     if market_data_type == MarketDataType.CRYPTO:
         return config.get_telegram_crypto_admin_id()
@@ -180,6 +224,27 @@ def get_dev_channel_id_from_market_data_type(market_data_type: MarketDataType):
 
 def print_telegram_message(res: telegram.Message):
     logging.info(f"Sent to {res.chat.title} {res.chat.type} at {res.date}. Message id {res.id}")
+
+
+def _resolve_crypto_signal_target(
+    requested_chat_id: str | None,
+    runtime_mode: RuntimeMode,
+):
+    if runtime_mode.use_dev_telegram or config.get_simulate_tradingview_traffic():
+        return crypto_dev_bot, config.get_telegram_crypto_dev_id()
+
+    resolved_chat_id = (
+        config.get_crypto_signal_recipient_id()
+        if requested_chat_id is None
+        else requested_chat_id
+    )
+    if resolved_chat_id == config.get_telegram_crypto_channel_id():
+        raise RuntimeError(
+            'Crypto signal delivery to the public crypto channel is disabled in phase 1'
+        )
+    if resolved_chat_id == config.get_telegram_crypto_dev_id():
+        return crypto_dev_bot, resolved_chat_id
+    return crypto_admin_bot, resolved_chat_id
 
 
 def _build_telegram_error_alert(context: str, error_text: str) -> str:

--- a/src/router/tradingview/tradingview.py
+++ b/src/router/tradingview/tradingview.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from typing import Any
 
 from fastapi import APIRouter, Request
 
@@ -15,6 +16,10 @@ from src.util.my_telegram import format_messages_to_telegram, escape_markdown
 router = APIRouter(prefix="/tradingview")
 
 logger = logging.getLogger('Trading view')
+MAX_ALERT_SAMPLE_COUNT = 5
+MAX_ALERT_FIELD_LENGTH = 32
+MAX_ALERT_SAMPLE_LENGTH = 80
+MAX_ALERT_SERIES_LENGTH = 5
 
 
 @router.post("/daily-stocks")
@@ -30,7 +35,7 @@ async def tradingview_daily_stocks_data(request: Request):
     try:
         body = await parse_tradingview_request_body(request)
         filtered_body = filter_tradingview_request_body(body)
-        logger.info(filtered_body)
+        log_tradingview_request_metadata(filtered_body, request.client.host)
     except Exception as e:
         logger.error(get_exception_message(e))
         messages.append(f"JSON body error: {get_exception_message(e, should_escape_markdown=True)}")
@@ -44,7 +49,7 @@ async def tradingview_daily_stocks_data(request: Request):
         messages.append(
             '*Ignored TradingView test_mode request in prod.*\n'
             f'*Request ip:* {escape_markdown(request.client.host)}\n'
-            f'*Body:* {escape_markdown(str(filtered_body))}'
+            f'{format_tradingview_alert_context(filtered_body)}'
         )
         async_ee.emit(
             'send_to_telegram',
@@ -56,7 +61,7 @@ async def tradingview_daily_stocks_data(request: Request):
 
     if not request_test_mode and body.get('secret', None) != config.get_tradingview_webhook_secret():
         messages.append(
-            f"*[Potential malicious request warning]‼️*\n*Incorrect tradingview webhook secret{escape_markdown('.')}*\n*Headers:* {escape_markdown(str(request.headers))}\n*Body:* {escape_markdown(str(body))}\n*Request ip:* {escape_markdown(request.client.host)}")
+            f"*[Potential malicious request warning]‼️*\n*Incorrect tradingview webhook secret{escape_markdown('.')}*\n*Request ip:* {escape_markdown(request.client.host)}\n{format_tradingview_alert_context(filtered_body)}")
         message = format_messages_to_telegram(messages)
         async_ee.emit('send_to_telegram', message=message, channel=config.get_telegram_stocks_admin_id(), market_data_type=MarketDataType.STOCKS)
         return {"data": "OK"}
@@ -65,7 +70,7 @@ async def tradingview_daily_stocks_data(request: Request):
     whitelist_ips = config.get_whitelist_ips()
     if not config.get_simulate_tradingview_traffic() and request.client.host not in trading_view_ips and request.client.host not in whitelist_ips:
         messages.append(
-            f"*[Potential malicious request warning]‼️*\n*Request ip {escape_markdown(request.client.host)} is not from trading view*: {escape_markdown(str(trading_view_ips))} or whitelist: {escape_markdown(str(whitelist_ips))}\n*Headers:* {escape_markdown(str(request.headers))}\n*Body:* {escape_markdown(str(filtered_body))}\n")
+            f"*[Potential malicious request warning]‼️*\n*Request ip {escape_markdown(request.client.host)} is not from a configured TradingView source or whitelist{escape_markdown('.')}*\n{format_tradingview_alert_context(filtered_body)}")
         message = format_messages_to_telegram(messages)
         async_ee.emit('send_to_telegram', message=message, channel=config.get_telegram_stocks_admin_id(), market_data_type=MarketDataType.STOCKS)
         return {"data": "OK"}
@@ -159,6 +164,100 @@ def parse_tradingview_body_text(raw_text: str):
 
 def filter_tradingview_request_body(body: dict) -> dict:
     return {k: v for k, v in body.items() if k != 'secret'}
+
+
+def format_tradingview_alert_context(body: dict) -> str:
+    payload = body.get('data') if isinstance(body, dict) else None
+    data = payload if isinstance(payload, list) else []
+    samples = []
+    for item in data[:MAX_ALERT_SAMPLE_COUNT]:
+        if not isinstance(item, dict):
+            continue
+        symbol = truncate_alert_value(item.get('symbol'), MAX_ALERT_FIELD_LENGTH)
+        timeframe = truncate_alert_value(
+            item.get('timeframe'),
+            MAX_ALERT_FIELD_LENGTH,
+        )
+        if symbol is None:
+            continue
+        sample = symbol
+        if timeframe is not None:
+            sample = f'{sample} {timeframe}'
+        samples.append(truncate_alert_value(sample, MAX_ALERT_SAMPLE_LENGTH))
+
+    context = [
+        f"*Payload type:* {format_alert_value(body.get('type'))}",
+        f"*Test mode:* {format_alert_value(body.get('test_mode'))}",
+        f"*Unix ms:* {format_alert_value(body.get('unix_ms'))}",
+        f"*Data item count:* {len(data)}",
+    ]
+    if samples:
+        context.append(f"*Sample symbols:* {escape_markdown(', '.join(samples))}")
+    preview = build_tradingview_payload_preview(body)
+    if preview:
+        context.append(f"*Payload preview:* `{escape_markdown(preview)}`")
+    return '\n'.join(context)
+
+
+def build_tradingview_payload_preview(body: dict) -> str:
+    payload = body.get('data') if isinstance(body, dict) else None
+    data = payload if isinstance(payload, list) else []
+    preview = {
+        'type': truncate_alert_value(body.get('type')),
+        'test_mode': truncate_alert_value(body.get('test_mode')),
+        'unix_ms': truncate_alert_value(body.get('unix_ms')),
+        'data': [
+            build_tradingview_item_preview(item)
+            for item in data[:MAX_ALERT_SAMPLE_COUNT]
+            if isinstance(item, dict)
+        ],
+    }
+    return json.dumps(preview, separators=(',', ':'))
+
+
+def build_tradingview_item_preview(item: dict) -> dict[str, Any]:
+    return {
+        'symbol': truncate_alert_value(item.get('symbol')),
+        'timeframe': truncate_alert_value(item.get('timeframe')),
+        'close_prices': truncate_alert_sequence(item.get('close_prices')),
+        'ema20s': truncate_alert_sequence(item.get('ema20s')),
+        'volumes': truncate_alert_sequence(item.get('volumes')),
+    }
+
+
+def log_tradingview_request_metadata(body: dict, client_host: str):
+    payload = body.get('data') if isinstance(body, dict) else None
+    data_count = len(payload) if isinstance(payload, list) else 0
+    logger.info(
+        'TradingView webhook payload metadata: client=%s type=%s test_mode=%s unix_ms=%s data_count=%s',
+        truncate_alert_value(client_host),
+        truncate_alert_value(body.get('type')),
+        truncate_alert_value(body.get('test_mode')),
+        truncate_alert_value(body.get('unix_ms')),
+        data_count,
+    )
+
+
+def format_alert_value(value) -> str:
+    return escape_markdown(str(truncate_alert_value(value)))
+
+
+def truncate_alert_value(value, max_length: int = MAX_ALERT_FIELD_LENGTH):
+    if value is None:
+        return None
+    text = str(value).replace('\n', ' ').replace('\r', ' ')
+    if len(text) <= max_length:
+        return text
+    return f'{text[: max_length - 3]}...'
+
+
+def truncate_alert_sequence(value):
+    if not isinstance(value, list):
+        return []
+    return [
+        truncate_alert_value(item)
+        for item in value[:MAX_ALERT_SERIES_LENGTH]
+    ]
 
 
 def get_tradingview_score(

--- a/src/server.py
+++ b/src/server.py
@@ -34,6 +34,12 @@ app.include_router(crypto_stats.router)
 env = os.getenv('ENV')
 
 logger = logging.getLogger('Server')
+PUBLIC_ROUTES = {
+    ('GET', '/healthz'),
+    ('POST', '/tradingview/daily-stocks'),
+}
+
+
 def start_server():
     logger.info('starting server...')
     reload = False
@@ -57,24 +63,32 @@ async def shutdown_event():
 @app.middleware("http")
 async def log_request_and_time_taken(request: Request, call_next):
     start_time = time.time()
-    logger.info(f"{request.method} {request.url}, headers: {request.headers} client: {request.client}")
+    logger.info(
+        "Request: method=%s path=%s client=%s",
+        request.method,
+        request.url.path,
+        request.client,
+    )
     response = await call_next(request)
     time_elapsed = time.time() - start_time
     response.headers["X-Process-Time"] = str(time_elapsed)
-    logger.info(f"Response: {response.headers}")
+    logger.info(
+        "Response: method=%s path=%s status=%s elapsed_seconds=%s",
+        request.method,
+        request.url.path,
+        response.status_code,
+        time_elapsed,
+    )
     return response
 
 @app.middleware("http")
 async def auth_check(request: Request, call_next):
-    if config.get_env() != 'prod' or 'localhost' in request.url.hostname:
-        logger.info('env is not prod or hostname is localhost. Skipping auth')
+    if config.get_env() != 'prod':
+        logger.info('env is not prod. Skipping auth')
         return await call_next(request)
 
-    excluded_endpoints = config.get_auth_exclude_endpoints()
-    if excluded_endpoints is not None:
-        for excluded_endpoint in excluded_endpoints:
-            if excluded_endpoint in request.url.path:
-                return await call_next(request)
+    if (request.method, request.url.path) in PUBLIC_ROUTES:
+        return await call_next(request)
 
     auth_token = request.headers.get('X-Api-Auth')
     if not auth_token or auth_token != config.get_api_auth_token():

--- a/src/service/crypto/crypto_stats.py
+++ b/src/service/crypto/crypto_stats.py
@@ -25,6 +25,17 @@ class CryptoStatsService:
         coin_detail: cmc_type.CMCCoinDetail = await self.cmc_service.get_coin_detail(id=id)
         return coin_detail.data
 
+    async def get_ohlcv_historical(
+        self,
+        id: int,
+        interval: str = '24h',
+    ) -> cmc_type.OHLCVHistorical:
+        data: cmc_type.CMCOHLCVHistorical = await self.cmc_service.get_ohlcv_historical(
+            id=id,
+            interval=interval,
+        )
+        return data.data
+
     async def get_sector_detail(self, sector_id: str) -> cmc_type.SectorDetail:
         data: cmc_type.CMCSectorDetail = await self.cmc_service.get_sector_detail(
             sector_id=sector_id

--- a/src/service/crypto_signal/backfill.py
+++ b/src/service/crypto_signal/backfill.py
@@ -16,6 +16,8 @@ from src.service.crypto_signal.repository import SNAPSHOT_VERSION
 
 logger = logging.getLogger('Crypto signal backfill')
 
+# Backfill only seeds enough retained history for phase-1 operator scoring; the
+# live crypto job remains the source of truth for current snapshots and delivery.
 BACKFILL_SOURCE_NAME = 'CMC historical bootstrap'
 BACKFILL_RUNTIME_MODE = 'bootstrap'
 BACKFILL_INTERVAL = '24h'

--- a/src/service/crypto_signal/backfill.py
+++ b/src/service/crypto_signal/backfill.py
@@ -1,0 +1,189 @@
+import asyncio
+import datetime
+import logging
+from collections import OrderedDict
+
+from market_data_library.types import cmc_type
+
+from src.service.crypto.crypto_stats import CryptoStatsService
+from src.service.crypto_signal.models import (
+    CryptoSignalCoinSnapshot,
+    CryptoSignalRunRecord,
+    CryptoSignalSnapshot,
+)
+from src.service.crypto_signal.repository import SNAPSHOT_VERSION
+
+
+logger = logging.getLogger('Crypto signal backfill')
+
+BACKFILL_SOURCE_NAME = 'CMC historical bootstrap'
+BACKFILL_RUNTIME_MODE = 'bootstrap'
+BACKFILL_INTERVAL = '24h'
+
+
+class CryptoSignalBackfillService:
+    def __init__(self, cmc_service: CryptoStatsService | None = None) -> None:
+        self.cmc_service = cmc_service or CryptoStatsService()
+
+    async def build_snapshots(
+        self,
+        coin_entries: list[tuple[str, int]],
+        watchlist_coin_ids: set[int],
+        current_timestamp_utc: datetime.datetime,
+        days: int,
+    ) -> list[CryptoSignalSnapshot]:
+        unique_entries = list(dict.fromkeys(coin_entries))
+        if len(unique_entries) == 0:
+            return []
+
+        history_results = await asyncio.gather(
+            *[
+                self.cmc_service.get_ohlcv_historical(
+                    id=coin_id,
+                    interval=BACKFILL_INTERVAL,
+                )
+                for _symbol, coin_id in unique_entries
+            ],
+            return_exceptions=True,
+        )
+
+        grouped_snapshots: OrderedDict[datetime.datetime, CryptoSignalSnapshot] = (
+            OrderedDict()
+        )
+        window_start_utc = current_timestamp_utc - datetime.timedelta(days=days)
+
+        for (symbol, coin_id), history_result in zip(
+            unique_entries,
+            history_results,
+            strict=False,
+        ):
+            if isinstance(history_result, Exception):
+                logger.warning(
+                    'Skipping crypto signal backfill for %s (%s): %s',
+                    symbol,
+                    coin_id,
+                    history_result,
+                )
+                continue
+            self._merge_coin_history(
+                grouped_snapshots=grouped_snapshots,
+                symbol=symbol,
+                coin_id=coin_id,
+                history=history_result,
+                watchlist_coin_ids=watchlist_coin_ids,
+                window_start_utc=window_start_utc,
+                current_timestamp_utc=current_timestamp_utc,
+            )
+
+        return list(grouped_snapshots.values())
+
+    def _merge_coin_history(
+        self,
+        grouped_snapshots: OrderedDict[datetime.datetime, CryptoSignalSnapshot],
+        symbol: str,
+        coin_id: int,
+        history: cmc_type.OHLCVHistorical,
+        watchlist_coin_ids: set[int],
+        window_start_utc: datetime.datetime,
+        current_timestamp_utc: datetime.datetime,
+    ) -> None:
+        sorted_quotes = sorted(
+            history.quotes,
+            key=lambda quote: self._parse_quote_timestamp(quote),
+        )
+        previous_quote: cmc_type.OHLCVHistoricalQuote | None = None
+
+        for quote in sorted_quotes:
+            quote_timestamp_utc = self._parse_quote_timestamp(quote)
+            # Provider quote timestamps follow candle/bucket boundaries rather
+            # than "time fetched". For 24h history, the API can still return
+            # today's in-progress candle labeled with the day-end timestamp,
+            # which may be later than the current live run time. Bootstrap rows
+            # should only represent completed past observations, so skip the
+            # current/future bucket here and let the live run persist its own
+            # snapshot separately.
+            if quote_timestamp_utc >= current_timestamp_utc:
+                previous_quote = quote
+                continue
+            if quote_timestamp_utc < window_start_utc:
+                # Preserve the last earlier candle so the first retained row can
+                # still compute a 24h change from real provider history.
+                previous_quote = quote
+                continue
+
+            snapshot = grouped_snapshots.get(quote_timestamp_utc)
+            if snapshot is None:
+                # Group all coins that share the same historical timestamp into
+                # one synthetic run so bootstrap data matches the normal
+                # one-run-many-coins storage model.
+                snapshot = CryptoSignalSnapshot(
+                    run=CryptoSignalRunRecord(
+                        run_timestamp_utc=quote_timestamp_utc,
+                        runtime_mode=BACKFILL_RUNTIME_MODE,
+                        source_name=BACKFILL_SOURCE_NAME,
+                        snapshot_version=SNAPSHOT_VERSION,
+                        sentiment_now_value=None,
+                        sentiment_now_label=None,
+                        sentiment_yesterday_value=None,
+                        sentiment_last_week_value=None,
+                        sentiment_7d_avg=None,
+                        sentiment_30d_avg=None,
+                        strongest_sector_id=None,
+                        strongest_sector_name=None,
+                        strongest_sector_avg_price_change_24h=None,
+                        strongest_sector_market_change_24h=None,
+                        strongest_sector_volume_change_24h=None,
+                        strongest_sector_gainers_num=None,
+                        strongest_sector_losers_num=None,
+                        weakest_sector_id=None,
+                        weakest_sector_name=None,
+                        weakest_sector_avg_price_change_24h=None,
+                        weakest_sector_market_change_24h=None,
+                        weakest_sector_volume_change_24h=None,
+                        weakest_sector_gainers_num=None,
+                        weakest_sector_losers_num=None,
+                    ),
+                    coins=[],
+                )
+                grouped_snapshots[quote_timestamp_utc] = snapshot
+
+            snapshot.coins.append(
+                CryptoSignalCoinSnapshot(
+                    coin_id=coin_id,
+                    symbol=history.symbol or symbol,
+                    name=history.name,
+                    price_usd=quote.quote.close,
+                    price_change_24h=self._calculate_change_pct(
+                        current_value=quote.quote.close,
+                        previous_value=(
+                            previous_quote.quote.close if previous_quote is not None else None
+                        ),
+                    ),
+                    volume_24h=quote.quote.volume,
+                    volume_change_pct_24h=self._calculate_change_pct(
+                        current_value=quote.quote.volume,
+                        previous_value=(
+                            previous_quote.quote.volume if previous_quote is not None else None
+                        ),
+                    ),
+                    is_watchlist=coin_id in watchlist_coin_ids,
+                    context_tags=('watchlist',) if coin_id in watchlist_coin_ids else (),
+                )
+            )
+            previous_quote = quote
+
+    @staticmethod
+    def _parse_quote_timestamp(
+        quote: cmc_type.OHLCVHistoricalQuote,
+    ) -> datetime.datetime:
+        raw_value = quote.quote.timestamp or quote.timeClose or quote.timeOpen
+        return datetime.datetime.fromisoformat(raw_value.replace('Z', '+00:00'))
+
+    @staticmethod
+    def _calculate_change_pct(
+        current_value: float | None,
+        previous_value: float | None,
+    ) -> float | None:
+        if current_value is None or previous_value is None or previous_value == 0:
+            return None
+        return ((current_value - previous_value) / previous_value) * 100

--- a/src/service/crypto_signal/models.py
+++ b/src/service/crypto_signal/models.py
@@ -59,6 +59,7 @@ class CryptoSignalCandidate:
     symbol: str
     name: str
     latest_price_usd: float | None
+    latest_volume_24h: float | None
     latest_price_change_24h: float | None
     latest_volume_change_pct_24h: float | None
     latest_context_tags: tuple[str, ...]

--- a/src/service/crypto_signal/models.py
+++ b/src/service/crypto_signal/models.py
@@ -1,0 +1,84 @@
+import datetime
+from dataclasses import dataclass, field
+
+
+@dataclass(slots=True)
+class CryptoSignalRunRecord:
+    run_timestamp_utc: datetime.datetime
+    runtime_mode: str
+    source_name: str
+    snapshot_version: int
+    sentiment_now_value: float | None
+    sentiment_now_label: str | None
+    sentiment_yesterday_value: float | None
+    sentiment_last_week_value: float | None
+    sentiment_7d_avg: float | None
+    sentiment_30d_avg: float | None
+    strongest_sector_id: str | None
+    strongest_sector_name: str | None
+    strongest_sector_avg_price_change_24h: float | None
+    strongest_sector_market_change_24h: float | None
+    strongest_sector_volume_change_24h: float | None
+    strongest_sector_gainers_num: int | None
+    strongest_sector_losers_num: int | None
+    weakest_sector_id: str | None
+    weakest_sector_name: str | None
+    weakest_sector_avg_price_change_24h: float | None
+    weakest_sector_market_change_24h: float | None
+    weakest_sector_volume_change_24h: float | None
+    weakest_sector_gainers_num: int | None
+    weakest_sector_losers_num: int | None
+    run_id: int | None = None
+    created_at_utc: datetime.datetime | None = None
+
+
+@dataclass(slots=True)
+class CryptoSignalCoinSnapshot:
+    coin_id: int
+    symbol: str
+    name: str
+    price_usd: float | None
+    price_change_24h: float | None
+    volume_24h: float | None
+    volume_change_pct_24h: float | None
+    is_watchlist: bool
+    context_tags: tuple[str, ...]
+    run_id: int | None = None
+    created_at_utc: datetime.datetime | None = None
+
+
+@dataclass(slots=True)
+class CryptoSignalSnapshot:
+    run: CryptoSignalRunRecord
+    coins: list[CryptoSignalCoinSnapshot] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class CryptoSignalCandidate:
+    coin_id: int
+    symbol: str
+    name: str
+    latest_price_usd: float | None
+    latest_price_change_24h: float | None
+    latest_volume_change_pct_24h: float | None
+    latest_context_tags: tuple[str, ...]
+    score: int
+    price_persistence_score: int
+    volume_confirmation_score: int
+    attention_persistence_score: int
+    breadth_alignment_score: int
+    observation_count: int
+    reason_tags: tuple[str, ...]
+    flags: tuple[str, ...]
+    is_watchlist: bool
+
+
+@dataclass(slots=True)
+class CryptoSignalDigestView:
+    latest_snapshot: CryptoSignalSnapshot
+    window_label: str
+    market_regime_label: str
+    market_regime_reason: str
+    strong_candidates: list[CryptoSignalCandidate] = field(default_factory=list)
+    weak_candidates: list[CryptoSignalCandidate] = field(default_factory=list)
+    watchlist_candidates: list[CryptoSignalCandidate] = field(default_factory=list)

--- a/src/service/crypto_signal/models.py
+++ b/src/service/crypto_signal/models.py
@@ -61,6 +61,7 @@ class CryptoSignalCandidate:
     latest_price_usd: float | None
     latest_volume_24h: float | None
     latest_price_change_24h: float | None
+    window_price_change_pct: float | None
     latest_volume_change_pct_24h: float | None
     latest_context_tags: tuple[str, ...]
     score: int

--- a/src/service/crypto_signal/repository.py
+++ b/src/service/crypto_signal/repository.py
@@ -153,6 +153,10 @@ class CryptoSignalRepository:
                 ON crypto_signal_coin_snapshots (symbol, run_id)
                 """
             )
+            # Current phase-1 reads filter one run via the (run_id, coin_id)
+            # primary key, then sort a small per-run coin set in memory. Add a
+            # (run_id, symbol, coin_id) index only if that per-run sort becomes
+            # visible at a larger retained universe size.
             connection.execute(
                 """
                 INSERT INTO crypto_signal_metadata (key, value)
@@ -336,27 +340,33 @@ class CryptoSignalRepository:
         coin_ids: list[int],
         start_timestamp_utc: datetime.datetime,
     ) -> dict[int, int]:
-        self.init_schema()
         unique_coin_ids = list(dict.fromkeys(coin_ids))
         if len(unique_coin_ids) == 0:
             return {}
+        counts = {coin_id: 0 for coin_id in unique_coin_ids}
+        if not Path(self.db_path).exists():
+            return counts
 
         placeholders = ','.join('?' for _ in unique_coin_ids)
         params = [self._format_timestamp(start_timestamp_utc), *unique_coin_ids]
         with self._connect() as connection:
-            rows = connection.execute(
-                f"""
-                SELECT coin.coin_id, COUNT(*) AS observation_count
-                FROM crypto_signal_coin_snapshots AS coin
-                INNER JOIN crypto_signal_runs AS run
-                  ON run.run_id = coin.run_id
-                WHERE run.run_timestamp_utc >= ?
-                  AND coin.coin_id IN ({placeholders})
-                GROUP BY coin.coin_id
-                """,
-                params,
-            ).fetchall()
-        counts = {coin_id: 0 for coin_id in unique_coin_ids}
+            try:
+                rows = connection.execute(
+                    f"""
+                    SELECT coin.coin_id, COUNT(*) AS observation_count
+                    FROM crypto_signal_coin_snapshots AS coin
+                    INNER JOIN crypto_signal_runs AS run
+                      ON run.run_id = coin.run_id
+                    WHERE run.run_timestamp_utc >= ?
+                      AND coin.coin_id IN ({placeholders})
+                    GROUP BY coin.coin_id
+                    """,
+                    params,
+                ).fetchall()
+            except sqlite3.OperationalError as error:
+                if 'no such table' in str(error):
+                    return counts
+                raise
         counts.update(
             {
                 int(row['coin_id']): int(row['observation_count'])

--- a/src/service/crypto_signal/repository.py
+++ b/src/service/crypto_signal/repository.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Iterable
 
 from src.config import config
+from src.runtime.runtime_mode import DEFAULT_RUNTIME_MODE, RuntimeMode
 from src.service.crypto_signal.models import (
     CryptoSignalCoinSnapshot,
     CryptoSignalRunRecord,
@@ -64,8 +65,17 @@ SCHEMA_DOCS = {
 
 
 class CryptoSignalRepository:
-    def __init__(self, db_path: str | None = None) -> None:
-        self.db_path = db_path or config.get_crypto_signal_db_path()
+    def __init__(
+        self,
+        db_path: str | None = None,
+        runtime_mode: RuntimeMode | None = None,
+    ) -> None:
+        active_runtime_mode = (
+            DEFAULT_RUNTIME_MODE if runtime_mode is None else runtime_mode
+        )
+        self.db_path = db_path or config.get_crypto_signal_db_path(
+            runtime_mode=active_runtime_mode
+        )
 
     def init_schema(self) -> None:
         db_parent = Path(self.db_path).parent
@@ -251,17 +261,130 @@ class CryptoSignalRepository:
             coin.created_at_utc = created_at_utc
         return snapshot
 
-    def get_latest_snapshot(self) -> CryptoSignalSnapshot | None:
+    def save_or_merge_snapshot(
+        self,
+        snapshot: CryptoSignalSnapshot,
+    ) -> CryptoSignalSnapshot:
         self.init_schema()
+        created_at_utc = self._utcnow()
+
         with self._connect() as connection:
-            run_row = connection.execute(
+            existing_run = connection.execute(
                 """
-                SELECT *
+                SELECT run_id, created_at_utc
                 FROM crypto_signal_runs
-                ORDER BY run_timestamp_utc DESC
-                LIMIT 1
-                """
+                WHERE run_timestamp_utc = ?
+                """,
+                (self._format_timestamp(snapshot.run.run_timestamp_utc),),
             ).fetchone()
+            if existing_run is None:
+                # Keep the normal write path authoritative for first creation so
+                # bootstrap merges and live writes share the same row shape.
+                return self.save_snapshot(snapshot)
+
+            run_id = int(existing_run['run_id'])
+            # Bootstrap history is assembled coin-by-coin, but the persisted
+            # model is one run per timestamp. Merge additional coins into the
+            # existing run instead of creating duplicate run rows.
+            connection.executemany(
+                """
+                INSERT INTO crypto_signal_coin_snapshots (
+                    run_id,
+                    coin_id,
+                    symbol,
+                    name,
+                    price_usd,
+                    price_change_24h,
+                    volume_24h,
+                    volume_change_pct_24h,
+                    is_watchlist,
+                    context_tags_json,
+                    created_at_utc
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(run_id, coin_id) DO UPDATE SET
+                    symbol=excluded.symbol,
+                    name=excluded.name,
+                    price_usd=excluded.price_usd,
+                    price_change_24h=excluded.price_change_24h,
+                    volume_24h=excluded.volume_24h,
+                    volume_change_pct_24h=excluded.volume_change_pct_24h,
+                    is_watchlist=excluded.is_watchlist,
+                    context_tags_json=excluded.context_tags_json,
+                    created_at_utc=excluded.created_at_utc
+                """,
+                [
+                    self._serialize_coin_snapshot(
+                        coin=coin,
+                        run_id=run_id,
+                        created_at_utc=created_at_utc,
+                    )
+                    for coin in snapshot.coins
+                ],
+            )
+            connection.commit()
+
+        existing_created_at = self._parse_timestamp(existing_run['created_at_utc'])
+        snapshot.run.run_id = run_id
+        snapshot.run.created_at_utc = existing_created_at
+        for coin in snapshot.coins:
+            coin.run_id = run_id
+            coin.created_at_utc = created_at_utc
+        return snapshot
+
+    def get_coin_observation_counts_since(
+        self,
+        coin_ids: list[int],
+        start_timestamp_utc: datetime.datetime,
+    ) -> dict[int, int]:
+        self.init_schema()
+        unique_coin_ids = list(dict.fromkeys(coin_ids))
+        if len(unique_coin_ids) == 0:
+            return {}
+
+        placeholders = ','.join('?' for _ in unique_coin_ids)
+        params = [self._format_timestamp(start_timestamp_utc), *unique_coin_ids]
+        with self._connect() as connection:
+            rows = connection.execute(
+                f"""
+                SELECT coin.coin_id, COUNT(*) AS observation_count
+                FROM crypto_signal_coin_snapshots AS coin
+                INNER JOIN crypto_signal_runs AS run
+                  ON run.run_id = coin.run_id
+                WHERE run.run_timestamp_utc >= ?
+                  AND coin.coin_id IN ({placeholders})
+                GROUP BY coin.coin_id
+                """,
+                params,
+            ).fetchall()
+        counts = {coin_id: 0 for coin_id in unique_coin_ids}
+        counts.update(
+            {
+                int(row['coin_id']): int(row['observation_count'])
+                for row in rows
+            }
+        )
+        return counts
+
+    def get_latest_snapshot(self) -> CryptoSignalSnapshot | None:
+        if not Path(self.db_path).exists():
+            return None
+        with self._connect() as connection:
+            try:
+                # The local report path must be able to inspect an existing DB
+                # through a read-only connection, so read helpers cannot call
+                # init_schema() or perform metadata writes here.
+                run_row = connection.execute(
+                    """
+                    SELECT *
+                    FROM crypto_signal_runs
+                    ORDER BY run_timestamp_utc DESC
+                    LIMIT 1
+                    """
+                ).fetchone()
+            except sqlite3.OperationalError as error:
+                if 'no such table' in str(error):
+                    return None
+                raise
             if run_row is None:
                 return None
             return self._build_snapshot_from_row(connection, run_row)
@@ -270,17 +393,23 @@ class CryptoSignalRepository:
         self,
         start_timestamp_utc: datetime.datetime,
     ) -> list[CryptoSignalSnapshot]:
-        self.init_schema()
+        if not Path(self.db_path).exists():
+            return []
         with self._connect() as connection:
-            run_rows = connection.execute(
-                """
-                SELECT *
-                FROM crypto_signal_runs
-                WHERE run_timestamp_utc >= ?
-                ORDER BY run_timestamp_utc ASC
-                """,
-                (self._format_timestamp(start_timestamp_utc),),
-            ).fetchall()
+            try:
+                run_rows = connection.execute(
+                    """
+                    SELECT *
+                    FROM crypto_signal_runs
+                    WHERE run_timestamp_utc >= ?
+                    ORDER BY run_timestamp_utc ASC
+                    """,
+                    (self._format_timestamp(start_timestamp_utc),),
+                ).fetchall()
+            except sqlite3.OperationalError as error:
+                if 'no such table' in str(error):
+                    return []
+                raise
             return [
                 self._build_snapshot_from_row(connection, run_row)
                 for run_row in run_rows

--- a/src/service/crypto_signal/repository.py
+++ b/src/service/crypto_signal/repository.py
@@ -1,0 +1,405 @@
+import datetime
+import json
+import sqlite3
+from pathlib import Path
+from typing import Iterable
+
+from src.config import config
+from src.service.crypto_signal.models import (
+    CryptoSignalCoinSnapshot,
+    CryptoSignalRunRecord,
+    CryptoSignalSnapshot,
+)
+
+
+SNAPSHOT_VERSION = 1
+
+SCHEMA_DOCS = {
+    'crypto_signal_metadata': {
+        'key': 'Metadata key. Phase 1 uses schema_version.',
+        'value': 'Metadata value stored as text.',
+    },
+    'crypto_signal_runs': {
+        'run_id': 'Synthetic run identifier used by child coin snapshot rows.',
+        'run_timestamp_utc': 'Canonical UTC observation timestamp for one crypto job run.',
+        'runtime_mode': 'Runtime mode label used when the job captured this snapshot.',
+        'source_name': 'Human-readable provider summary for the snapshot source.',
+        'snapshot_version': 'Snapshot schema version for forward compatibility.',
+        'sentiment_now_value': 'Alternative.me fear and greed value for Now.',
+        'sentiment_now_label': 'Alternative.me sentiment label for Now.',
+        'sentiment_yesterday_value': 'Alternative.me fear and greed value for Yesterday.',
+        'sentiment_last_week_value': 'Alternative.me fear and greed value for Last week.',
+        'sentiment_7d_avg': 'Seven-day fear and greed average when available.',
+        'sentiment_30d_avg': 'Thirty-day fear and greed average when available.',
+        'strongest_sector_id': 'CMC sector id for the strongest 24h sector.',
+        'strongest_sector_name': 'CMC strongest-sector display name.',
+        'strongest_sector_avg_price_change_24h': 'Average 24h price change for the strongest sector.',
+        'strongest_sector_market_change_24h': 'Aggregate 24h market-cap change for the strongest sector.',
+        'strongest_sector_volume_change_24h': 'Aggregate 24h volume change for the strongest sector.',
+        'strongest_sector_gainers_num': 'Reported count of gainers inside the strongest sector.',
+        'strongest_sector_losers_num': 'Reported count of losers inside the strongest sector.',
+        'weakest_sector_id': 'CMC sector id for the weakest 24h sector.',
+        'weakest_sector_name': 'CMC weakest-sector display name.',
+        'weakest_sector_avg_price_change_24h': 'Average 24h price change for the weakest sector.',
+        'weakest_sector_market_change_24h': 'Aggregate 24h market-cap change for the weakest sector.',
+        'weakest_sector_volume_change_24h': 'Aggregate 24h volume change for the weakest sector.',
+        'weakest_sector_gainers_num': 'Reported count of gainers inside the weakest sector.',
+        'weakest_sector_losers_num': 'Reported count of losers inside the weakest sector.',
+        'created_at_utc': 'UTC write timestamp for the persisted run row.',
+    },
+    'crypto_signal_coin_snapshots': {
+        'run_id': 'Foreign key to crypto_signal_runs.',
+        'coin_id': 'CMC coin identifier.',
+        'symbol': 'Coin ticker symbol at observation time.',
+        'name': 'Coin display name at observation time.',
+        'price_usd': 'Latest USD price captured by the digest job.',
+        'price_change_24h': 'Observed 24h price change percentage.',
+        'volume_24h': 'Observed 24h volume in USD terms.',
+        'volume_change_pct_24h': 'Observed 24h volume change percentage.',
+        'is_watchlist': '1 when the configured watchlist included this coin for the run.',
+        'context_tags_json': 'Stable JSON array describing how the coin entered the snapshot.',
+        'created_at_utc': 'UTC write timestamp for the persisted coin row.',
+    },
+}
+
+
+class CryptoSignalRepository:
+    def __init__(self, db_path: str | None = None) -> None:
+        self.db_path = db_path or config.get_crypto_signal_db_path()
+
+    def init_schema(self) -> None:
+        db_parent = Path(self.db_path).parent
+        db_parent.mkdir(parents=True, exist_ok=True)
+
+        with self._connect() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS crypto_signal_metadata (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS crypto_signal_runs (
+                    run_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    run_timestamp_utc TEXT NOT NULL UNIQUE,
+                    runtime_mode TEXT NOT NULL,
+                    source_name TEXT NOT NULL,
+                    snapshot_version INTEGER NOT NULL,
+                    sentiment_now_value REAL NULL,
+                    sentiment_now_label TEXT NULL,
+                    sentiment_yesterday_value REAL NULL,
+                    sentiment_last_week_value REAL NULL,
+                    sentiment_7d_avg REAL NULL,
+                    sentiment_30d_avg REAL NULL,
+                    strongest_sector_id TEXT NULL,
+                    strongest_sector_name TEXT NULL,
+                    strongest_sector_avg_price_change_24h REAL NULL,
+                    strongest_sector_market_change_24h REAL NULL,
+                    strongest_sector_volume_change_24h REAL NULL,
+                    strongest_sector_gainers_num INTEGER NULL,
+                    strongest_sector_losers_num INTEGER NULL,
+                    weakest_sector_id TEXT NULL,
+                    weakest_sector_name TEXT NULL,
+                    weakest_sector_avg_price_change_24h REAL NULL,
+                    weakest_sector_market_change_24h REAL NULL,
+                    weakest_sector_volume_change_24h REAL NULL,
+                    weakest_sector_gainers_num INTEGER NULL,
+                    weakest_sector_losers_num INTEGER NULL,
+                    created_at_utc TEXT NOT NULL
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS crypto_signal_coin_snapshots (
+                    run_id INTEGER NOT NULL,
+                    coin_id INTEGER NOT NULL,
+                    symbol TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    price_usd REAL NULL,
+                    price_change_24h REAL NULL,
+                    volume_24h REAL NULL,
+                    volume_change_pct_24h REAL NULL,
+                    is_watchlist INTEGER NOT NULL,
+                    context_tags_json TEXT NOT NULL,
+                    created_at_utc TEXT NOT NULL,
+                    PRIMARY KEY (run_id, coin_id),
+                    FOREIGN KEY (run_id) REFERENCES crypto_signal_runs(run_id)
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_crypto_signal_coin_snapshots_coin_id_run_id
+                ON crypto_signal_coin_snapshots (coin_id, run_id)
+                """
+            )
+            connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_crypto_signal_coin_snapshots_symbol_run_id
+                ON crypto_signal_coin_snapshots (symbol, run_id)
+                """
+            )
+            connection.execute(
+                """
+                INSERT INTO crypto_signal_metadata (key, value)
+                VALUES ('schema_version', ?)
+                ON CONFLICT(key) DO UPDATE SET value=excluded.value
+                """,
+                (str(SNAPSHOT_VERSION),),
+            )
+            connection.commit()
+
+    def save_snapshot(self, snapshot: CryptoSignalSnapshot) -> CryptoSignalSnapshot:
+        self.init_schema()
+        created_at_utc = self._utcnow()
+
+        with self._connect() as connection:
+            cursor = connection.execute(
+                """
+                INSERT INTO crypto_signal_runs (
+                    run_timestamp_utc,
+                    runtime_mode,
+                    source_name,
+                    snapshot_version,
+                    sentiment_now_value,
+                    sentiment_now_label,
+                    sentiment_yesterday_value,
+                    sentiment_last_week_value,
+                    sentiment_7d_avg,
+                    sentiment_30d_avg,
+                    strongest_sector_id,
+                    strongest_sector_name,
+                    strongest_sector_avg_price_change_24h,
+                    strongest_sector_market_change_24h,
+                    strongest_sector_volume_change_24h,
+                    strongest_sector_gainers_num,
+                    strongest_sector_losers_num,
+                    weakest_sector_id,
+                    weakest_sector_name,
+                    weakest_sector_avg_price_change_24h,
+                    weakest_sector_market_change_24h,
+                    weakest_sector_volume_change_24h,
+                    weakest_sector_gainers_num,
+                    weakest_sector_losers_num,
+                    created_at_utc
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    self._format_timestamp(snapshot.run.run_timestamp_utc),
+                    snapshot.run.runtime_mode,
+                    snapshot.run.source_name,
+                    snapshot.run.snapshot_version,
+                    snapshot.run.sentiment_now_value,
+                    snapshot.run.sentiment_now_label,
+                    snapshot.run.sentiment_yesterday_value,
+                    snapshot.run.sentiment_last_week_value,
+                    snapshot.run.sentiment_7d_avg,
+                    snapshot.run.sentiment_30d_avg,
+                    snapshot.run.strongest_sector_id,
+                    snapshot.run.strongest_sector_name,
+                    snapshot.run.strongest_sector_avg_price_change_24h,
+                    snapshot.run.strongest_sector_market_change_24h,
+                    snapshot.run.strongest_sector_volume_change_24h,
+                    snapshot.run.strongest_sector_gainers_num,
+                    snapshot.run.strongest_sector_losers_num,
+                    snapshot.run.weakest_sector_id,
+                    snapshot.run.weakest_sector_name,
+                    snapshot.run.weakest_sector_avg_price_change_24h,
+                    snapshot.run.weakest_sector_market_change_24h,
+                    snapshot.run.weakest_sector_volume_change_24h,
+                    snapshot.run.weakest_sector_gainers_num,
+                    snapshot.run.weakest_sector_losers_num,
+                    self._format_timestamp(created_at_utc),
+                ),
+            )
+            run_id = int(cursor.lastrowid)
+            connection.executemany(
+                """
+                INSERT INTO crypto_signal_coin_snapshots (
+                    run_id,
+                    coin_id,
+                    symbol,
+                    name,
+                    price_usd,
+                    price_change_24h,
+                    volume_24h,
+                    volume_change_pct_24h,
+                    is_watchlist,
+                    context_tags_json,
+                    created_at_utc
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    self._serialize_coin_snapshot(
+                        coin=coin,
+                        run_id=run_id,
+                        created_at_utc=created_at_utc,
+                    )
+                    for coin in snapshot.coins
+                ],
+            )
+            connection.commit()
+
+        snapshot.run.run_id = run_id
+        snapshot.run.created_at_utc = created_at_utc
+        for coin in snapshot.coins:
+            coin.run_id = run_id
+            coin.created_at_utc = created_at_utc
+        return snapshot
+
+    def get_latest_snapshot(self) -> CryptoSignalSnapshot | None:
+        self.init_schema()
+        with self._connect() as connection:
+            run_row = connection.execute(
+                """
+                SELECT *
+                FROM crypto_signal_runs
+                ORDER BY run_timestamp_utc DESC
+                LIMIT 1
+                """
+            ).fetchone()
+            if run_row is None:
+                return None
+            return self._build_snapshot_from_row(connection, run_row)
+
+    def get_snapshots_since(
+        self,
+        start_timestamp_utc: datetime.datetime,
+    ) -> list[CryptoSignalSnapshot]:
+        self.init_schema()
+        with self._connect() as connection:
+            run_rows = connection.execute(
+                """
+                SELECT *
+                FROM crypto_signal_runs
+                WHERE run_timestamp_utc >= ?
+                ORDER BY run_timestamp_utc ASC
+                """,
+                (self._format_timestamp(start_timestamp_utc),),
+            ).fetchall()
+            return [
+                self._build_snapshot_from_row(connection, run_row)
+                for run_row in run_rows
+            ]
+
+    def _build_snapshot_from_row(
+        self,
+        connection: sqlite3.Connection,
+        run_row: sqlite3.Row,
+    ) -> CryptoSignalSnapshot:
+        coin_rows = connection.execute(
+            """
+            SELECT *
+            FROM crypto_signal_coin_snapshots
+            WHERE run_id = ?
+            ORDER BY symbol ASC, coin_id ASC
+            """,
+            (run_row['run_id'],),
+        ).fetchall()
+        return CryptoSignalSnapshot(
+            run=self._build_run_record(run_row),
+            coins=[self._build_coin_snapshot(row) for row in coin_rows],
+        )
+
+    def _build_run_record(self, row: sqlite3.Row) -> CryptoSignalRunRecord:
+        return CryptoSignalRunRecord(
+            run_id=row['run_id'],
+            run_timestamp_utc=self._parse_timestamp(row['run_timestamp_utc']),
+            runtime_mode=row['runtime_mode'],
+            source_name=row['source_name'],
+            snapshot_version=row['snapshot_version'],
+            sentiment_now_value=row['sentiment_now_value'],
+            sentiment_now_label=row['sentiment_now_label'],
+            sentiment_yesterday_value=row['sentiment_yesterday_value'],
+            sentiment_last_week_value=row['sentiment_last_week_value'],
+            sentiment_7d_avg=row['sentiment_7d_avg'],
+            sentiment_30d_avg=row['sentiment_30d_avg'],
+            strongest_sector_id=row['strongest_sector_id'],
+            strongest_sector_name=row['strongest_sector_name'],
+            strongest_sector_avg_price_change_24h=row['strongest_sector_avg_price_change_24h'],
+            strongest_sector_market_change_24h=row['strongest_sector_market_change_24h'],
+            strongest_sector_volume_change_24h=row['strongest_sector_volume_change_24h'],
+            strongest_sector_gainers_num=row['strongest_sector_gainers_num'],
+            strongest_sector_losers_num=row['strongest_sector_losers_num'],
+            weakest_sector_id=row['weakest_sector_id'],
+            weakest_sector_name=row['weakest_sector_name'],
+            weakest_sector_avg_price_change_24h=row['weakest_sector_avg_price_change_24h'],
+            weakest_sector_market_change_24h=row['weakest_sector_market_change_24h'],
+            weakest_sector_volume_change_24h=row['weakest_sector_volume_change_24h'],
+            weakest_sector_gainers_num=row['weakest_sector_gainers_num'],
+            weakest_sector_losers_num=row['weakest_sector_losers_num'],
+            created_at_utc=self._parse_timestamp(row['created_at_utc']),
+        )
+
+    def _build_coin_snapshot(self, row: sqlite3.Row) -> CryptoSignalCoinSnapshot:
+        return CryptoSignalCoinSnapshot(
+            run_id=row['run_id'],
+            coin_id=row['coin_id'],
+            symbol=row['symbol'],
+            name=row['name'],
+            price_usd=row['price_usd'],
+            price_change_24h=row['price_change_24h'],
+            volume_24h=row['volume_24h'],
+            volume_change_pct_24h=row['volume_change_pct_24h'],
+            is_watchlist=bool(row['is_watchlist']),
+            context_tags=tuple(json.loads(row['context_tags_json'])),
+            created_at_utc=self._parse_timestamp(row['created_at_utc']),
+        )
+
+    def _serialize_coin_snapshot(
+        self,
+        coin: CryptoSignalCoinSnapshot,
+        run_id: int,
+        created_at_utc: datetime.datetime,
+    ) -> tuple:
+        return (
+            run_id,
+            coin.coin_id,
+            coin.symbol,
+            coin.name,
+            coin.price_usd,
+            coin.price_change_24h,
+            coin.volume_24h,
+            coin.volume_change_pct_24h,
+            int(coin.is_watchlist),
+            json.dumps(list(coin.context_tags), separators=(',', ':')),
+            self._format_timestamp(created_at_utc),
+        )
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.db_path)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    @staticmethod
+    def _utcnow() -> datetime.datetime:
+        return datetime.datetime.now(tz=datetime.timezone.utc).replace(
+            microsecond=0
+        )
+
+    @staticmethod
+    def _format_timestamp(value: datetime.datetime) -> str:
+        return (
+            value.astimezone(datetime.timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+            .replace('+00:00', 'Z')
+        )
+
+    @staticmethod
+    def _parse_timestamp(value: str) -> datetime.datetime:
+        return datetime.datetime.fromisoformat(value.replace('Z', '+00:00'))
+
+
+def iter_snapshot_coin_ids(
+    snapshots: Iterable[CryptoSignalSnapshot],
+) -> list[int]:
+    seen_coin_ids: dict[int, None] = {}
+    for snapshot in snapshots:
+        for coin in snapshot.coins:
+            seen_coin_ids.setdefault(coin.coin_id, None)
+    return list(seen_coin_ids.keys())

--- a/src/service/crypto_signal/scorer.py
+++ b/src/service/crypto_signal/scorer.py
@@ -22,15 +22,14 @@ _WINDOW_LENGTHS = {
     '30d': datetime.timedelta(days=30),
 }
 
-_POSITIVE_ATTENTION_TAGS = {
+_BULLISH_ATTENTION_TAGS = {
     'spotlight_trending',
     'spotlight_gainer',
-    'sector_leader_strongest',
 }
 
-_NEGATIVE_ATTENTION_TAGS = {
+_BEARISH_ATTENTION_TAGS = {
+    'spotlight_trending',
     'spotlight_loser',
-    'sector_loser_weakest',
 }
 
 _MIN_OBSERVATIONS_TO_SCORE = 2
@@ -50,8 +49,14 @@ def build_digest_view(
     history: list[CryptoSignalSnapshot],
     watchlist_coin_ids: set[int],
     window_label: str,
+    tracked_universe_coin_ids: set[int] | None = None,
     limit: int = 3,
+    min_dynamic_price_usd: float = 1.0,
+    min_dynamic_volume_24h: float = 50_000_000.0,
 ) -> CryptoSignalDigestView:
+    tracked_universe_coin_ids = (
+        set() if tracked_universe_coin_ids is None else tracked_universe_coin_ids
+    )
     latest_coins_by_id = {coin.coin_id: coin for coin in latest_snapshot.coins}
     history_by_coin_id: dict[int, list[CryptoSignalCoinSnapshot]] = defaultdict(list)
     for snapshot in history:
@@ -71,11 +76,30 @@ def build_digest_view(
         candidate.coin_id: candidate for candidate in candidates
     }
 
+    # Strong/weak sections are the operator-ranked output, so they apply the
+    # dynamic-candidate tradability floor. Watchlist continuity is handled
+    # separately below and tracked-universe coins bypass the dynamic floor.
     strong_candidates = [
-        candidate for candidate in candidates if candidate.score >= 2
+        candidate
+        for candidate in candidates
+        if candidate.score >= 2
+        and _is_rankable_candidate(
+            candidate=candidate,
+            tracked_universe_coin_ids=tracked_universe_coin_ids,
+            min_dynamic_price_usd=min_dynamic_price_usd,
+            min_dynamic_volume_24h=min_dynamic_volume_24h,
+        )
     ]
     weak_candidates = [
-        candidate for candidate in candidates if candidate.score <= -2
+        candidate
+        for candidate in candidates
+        if candidate.score <= -2
+        and _is_rankable_candidate(
+            candidate=candidate,
+            tracked_universe_coin_ids=tracked_universe_coin_ids,
+            min_dynamic_price_usd=min_dynamic_price_usd,
+            min_dynamic_volume_24h=min_dynamic_volume_24h,
+        )
     ]
     watchlist_candidates = [
         candidates_by_coin_id[coin_id]
@@ -88,6 +112,9 @@ def build_digest_view(
         recent_history = history_by_coin_id.get(coin_id)
         if not recent_history:
             continue
+        # Keep the watchlist section stable even when the latest live snapshot
+        # omitted the coin, as long as there is still recent retained history
+        # inside the requested analysis window.
         watchlist_candidates.append(
             _build_candidate(
                 latest_coin=recent_history[-1],
@@ -141,16 +168,19 @@ def _build_candidate(
         breadth_alignment_score = 0
     else:
         price_persistence_score = _score_price_persistence(price_changes)
-        trend_sign = _sign(
-            price_persistence_score,
-            fallback=latest_coin.price_change_24h,
-        )
+        trend_sign = _sign(price_persistence_score)
         volume_confirmation_score = _score_volume_confirmation(
             trend_sign=trend_sign,
             volume_changes=volume_changes,
         )
-        attention_persistence_score = _score_attention_persistence(history)
-        breadth_alignment_score = _score_breadth_alignment(history)
+        attention_persistence_score = _score_attention_persistence(
+            trend_sign=trend_sign,
+            history=history,
+        )
+        breadth_alignment_score = _score_breadth_alignment(
+            trend_sign=trend_sign,
+            history=history,
+        )
     total_score = (
         price_persistence_score
         + volume_confirmation_score
@@ -158,6 +188,8 @@ def _build_candidate(
         + breadth_alignment_score
     )
 
+    # Flags add explanatory context to the rendered digest, but they are not
+    # additional score components in the phase-1 heuristic.
     flags = []
     expected_observations = EXPECTED_OBSERVATIONS_BY_WINDOW[window_label]
     if observation_count < max(2, expected_observations // 2):
@@ -183,6 +215,7 @@ def _build_candidate(
         symbol=latest_coin.symbol,
         name=latest_coin.name,
         latest_price_usd=latest_coin.price_usd,
+        latest_volume_24h=latest_coin.volume_24h,
         latest_price_change_24h=latest_coin.price_change_24h,
         latest_volume_change_pct_24h=latest_coin.volume_change_pct_24h,
         latest_context_tags=latest_coin.context_tags,
@@ -206,6 +239,8 @@ def _score_price_persistence(price_changes: list[float]) -> int:
     negative_hits = len([change for change in price_changes if change < 0])
     balance = (positive_hits - negative_hits) / len(price_changes)
     average_change = mean(price_changes)
+    # Mix direction consistency with average move size so one outsized candle
+    # does not dominate the signal if the rest of the window disagrees.
     average_component = _clamp(average_change / 15.0, -1.0, 1.0)
     return int(round(_clamp((balance * 0.7 + average_component * 0.3) * 4, -4, 4)))
 
@@ -217,48 +252,75 @@ def _score_volume_confirmation(
     if trend_sign == 0 or len(volume_changes) == 0:
         return 0
 
-    volume_support = _clamp(mean(volume_changes) / 30.0, -1.0, 1.0)
-    return int(round(_clamp(trend_sign * volume_support * 2, -2, 2)))
+    # Volume only confirms an existing price direction in phase 1; it is not
+    # allowed to create a directional signal on its own.
+    return trend_sign * 2 if mean(volume_changes) >= 15 else 0
 
 
-def _score_attention_persistence(history: list[CryptoSignalCoinSnapshot]) -> int:
-    if len(history) == 0:
+def _score_attention_persistence(
+    trend_sign: int,
+    history: list[CryptoSignalCoinSnapshot],
+) -> int:
+    if trend_sign == 0 or len(history) == 0:
         return 0
 
-    positive_hits = len(
-        [
-            coin for coin in history
-            if any(tag in _POSITIVE_ATTENTION_TAGS for tag in coin.context_tags)
-        ]
+    # `spotlight_trending` is directional only in combination with the
+    # surrounding price signal, so phase 1 counts it toward both bullish and
+    # bearish persistence depending on `trend_sign`.
+    relevant_tags = (
+        _BULLISH_ATTENTION_TAGS if trend_sign > 0 else _BEARISH_ATTENTION_TAGS
     )
-    negative_hits = len(
-        [
-            coin for coin in history
-            if any(tag in _NEGATIVE_ATTENTION_TAGS for tag in coin.context_tags)
-        ]
+    spotlight_hits = sum(
+        1
+        for coin in history
+        for tag in coin.context_tags
+        if tag in relevant_tags
     )
-    balance = (positive_hits - negative_hits) / len(history)
-    return int(round(_clamp(balance * 2, -2, 2)))
+    if spotlight_hits >= 4:
+        return trend_sign * 2
+    if spotlight_hits >= 2:
+        return trend_sign
+    return 0
 
 
-def _score_breadth_alignment(history: list[CryptoSignalCoinSnapshot]) -> int:
-    if len(history) == 0:
+def _score_breadth_alignment(
+    trend_sign: int,
+    history: list[CryptoSignalCoinSnapshot],
+) -> int:
+    if trend_sign == 0 or len(history) == 0:
         return 0
 
-    strongest_leader_hits = len(
-        [
-            coin for coin in history
-            if 'sector_leader_strongest' in coin.context_tags
-        ]
+    if trend_sign > 0:
+        return (
+            1
+            if any('sector_leader_strongest' in coin.context_tags for coin in history)
+            else 0
+        )
+    return (
+        -1
+        if any('sector_loser_weakest' in coin.context_tags for coin in history)
+        else 0
     )
-    weakest_loser_hits = len(
-        [
-            coin for coin in history
-            if 'sector_loser_weakest' in coin.context_tags
-        ]
+
+
+def _is_rankable_candidate(
+    candidate: CryptoSignalCandidate,
+    tracked_universe_coin_ids: set[int],
+    min_dynamic_price_usd: float,
+    min_dynamic_volume_24h: float,
+) -> bool:
+    # Tracked-universe names stay eligible even when they fail the dynamic
+    # floor because the filter is for operator ranking, not persistence scope.
+    if candidate.coin_id in tracked_universe_coin_ids:
+        return True
+    # Keep persistence broad, but apply a lightweight tradability floor before
+    # ranking dynamic names into the operator-facing strong/weak sections.
+    if candidate.latest_price_usd is None or candidate.latest_volume_24h is None:
+        return False
+    return (
+        candidate.latest_price_usd >= min_dynamic_price_usd
+        and candidate.latest_volume_24h >= min_dynamic_volume_24h
     )
-    balance = (strongest_leader_hits - weakest_loser_hits) / len(history)
-    return int(round(_clamp(balance, -1, 1)))
 
 
 def _classify_market_regime(
@@ -286,7 +348,7 @@ def _classify_market_regime(
     )
 
 
-def _sign(value: int, fallback: float | None) -> int:
+def _sign(value: int, fallback: float | None = None) -> int:
     if value > 0:
         return 1
     if value < 0:

--- a/src/service/crypto_signal/scorer.py
+++ b/src/service/crypto_signal/scorer.py
@@ -10,6 +10,9 @@ from src.service.crypto_signal.models import (
 )
 
 
+# Phase 1 is an operator-review ranking heuristic, not a trading system. Price
+# persistence sets direction; volume, attention, breadth, and sentiment only
+# confirm, contextualize, or explain that direction.
 EXPECTED_OBSERVATIONS_BY_WINDOW = {
     '3d': 6,
     '7d': 14,
@@ -32,6 +35,8 @@ _BEARISH_ATTENTION_TAGS = {
     'spotlight_loser',
 }
 
+# Require at least two observations so a single 24h move cannot masquerade as a
+# window trend.
 _MIN_OBSERVATIONS_TO_SCORE = 2
 
 
@@ -235,6 +240,8 @@ def _build_candidate(
 def _calculate_window_price_change_pct(
     history: list[CryptoSignalCoinSnapshot],
 ) -> float | None:
+    # Callers pass history ordered oldest-to-newest by run timestamp. The window
+    # move is a first-to-last price return, separate from 24h persistence scoring.
     priced_history = [
         coin for coin in history
         if coin.price_usd is not None and coin.price_usd > 0

--- a/src/service/crypto_signal/scorer.py
+++ b/src/service/crypto_signal/scorer.py
@@ -217,6 +217,7 @@ def _build_candidate(
         latest_price_usd=latest_coin.price_usd,
         latest_volume_24h=latest_coin.volume_24h,
         latest_price_change_24h=latest_coin.price_change_24h,
+        window_price_change_pct=_calculate_window_price_change_pct(history),
         latest_volume_change_pct_24h=latest_coin.volume_change_pct_24h,
         latest_context_tags=latest_coin.context_tags,
         score=total_score,
@@ -229,6 +230,23 @@ def _build_candidate(
         flags=tuple(flags),
         is_watchlist=latest_coin.is_watchlist,
     )
+
+
+def _calculate_window_price_change_pct(
+    history: list[CryptoSignalCoinSnapshot],
+) -> float | None:
+    priced_history = [
+        coin for coin in history
+        if coin.price_usd is not None and coin.price_usd > 0
+    ]
+    if len(priced_history) < 2:
+        return None
+
+    first_price = priced_history[0].price_usd
+    latest_price = priced_history[-1].price_usd
+    if first_price is None or latest_price is None:
+        return None
+    return ((latest_price - first_price) / first_price) * 100
 
 
 def _score_price_persistence(price_changes: list[float]) -> int:

--- a/src/service/crypto_signal/scorer.py
+++ b/src/service/crypto_signal/scorer.py
@@ -1,0 +1,331 @@
+import datetime
+from collections import defaultdict
+from statistics import mean
+
+from src.service.crypto_signal.models import (
+    CryptoSignalCandidate,
+    CryptoSignalCoinSnapshot,
+    CryptoSignalDigestView,
+    CryptoSignalSnapshot,
+)
+
+
+EXPECTED_OBSERVATIONS_BY_WINDOW = {
+    '3d': 6,
+    '7d': 14,
+    '30d': 60,
+}
+
+_WINDOW_LENGTHS = {
+    '3d': datetime.timedelta(days=3),
+    '7d': datetime.timedelta(days=7),
+    '30d': datetime.timedelta(days=30),
+}
+
+_POSITIVE_ATTENTION_TAGS = {
+    'spotlight_trending',
+    'spotlight_gainer',
+    'sector_leader_strongest',
+}
+
+_NEGATIVE_ATTENTION_TAGS = {
+    'spotlight_loser',
+    'sector_loser_weakest',
+}
+
+_MIN_OBSERVATIONS_TO_SCORE = 2
+
+
+def get_window_start(
+    latest_snapshot: CryptoSignalSnapshot,
+    window_label: str,
+) -> datetime.datetime:
+    if window_label not in _WINDOW_LENGTHS:
+        raise RuntimeError(f'Unsupported crypto signal window: {window_label}')
+    return latest_snapshot.run.run_timestamp_utc - _WINDOW_LENGTHS[window_label]
+
+
+def build_digest_view(
+    latest_snapshot: CryptoSignalSnapshot,
+    history: list[CryptoSignalSnapshot],
+    watchlist_coin_ids: set[int],
+    window_label: str,
+    limit: int = 3,
+) -> CryptoSignalDigestView:
+    latest_coins_by_id = {coin.coin_id: coin for coin in latest_snapshot.coins}
+    history_by_coin_id: dict[int, list[CryptoSignalCoinSnapshot]] = defaultdict(list)
+    for snapshot in history:
+        for coin in snapshot.coins:
+            history_by_coin_id[coin.coin_id].append(coin)
+
+    candidates = [
+        _build_candidate(
+            latest_coin=latest_coin,
+            history=history_by_coin_id.get(latest_coin.coin_id, [latest_coin]),
+            latest_snapshot=latest_snapshot,
+            window_label=window_label,
+        )
+        for latest_coin in latest_coins_by_id.values()
+    ]
+    candidates_by_coin_id = {
+        candidate.coin_id: candidate for candidate in candidates
+    }
+
+    strong_candidates = [
+        candidate for candidate in candidates if candidate.score >= 2
+    ]
+    weak_candidates = [
+        candidate for candidate in candidates if candidate.score <= -2
+    ]
+    watchlist_candidates = [
+        candidates_by_coin_id[coin_id]
+        for coin_id in watchlist_coin_ids
+        if coin_id in candidates_by_coin_id
+    ]
+    for coin_id in sorted(watchlist_coin_ids):
+        if coin_id in candidates_by_coin_id:
+            continue
+        recent_history = history_by_coin_id.get(coin_id)
+        if not recent_history:
+            continue
+        watchlist_candidates.append(
+            _build_candidate(
+                latest_coin=recent_history[-1],
+                history=recent_history,
+                latest_snapshot=latest_snapshot,
+                window_label=window_label,
+            )
+        )
+
+    strong_candidates.sort(key=lambda candidate: (-candidate.score, candidate.symbol))
+    weak_candidates.sort(key=lambda candidate: (candidate.score, candidate.symbol))
+    watchlist_candidates.sort(
+        key=lambda candidate: (-abs(candidate.score), candidate.symbol)
+    )
+
+    market_regime_label, market_regime_reason = _classify_market_regime(latest_snapshot)
+
+    return CryptoSignalDigestView(
+        latest_snapshot=latest_snapshot,
+        window_label=window_label,
+        market_regime_label=market_regime_label,
+        market_regime_reason=market_regime_reason,
+        strong_candidates=strong_candidates[:limit],
+        weak_candidates=weak_candidates[:limit],
+        watchlist_candidates=watchlist_candidates[:limit],
+    )
+
+
+def _build_candidate(
+    latest_coin: CryptoSignalCoinSnapshot,
+    history: list[CryptoSignalCoinSnapshot],
+    latest_snapshot: CryptoSignalSnapshot,
+    window_label: str,
+) -> CryptoSignalCandidate:
+    price_changes = [
+        coin.price_change_24h
+        for coin in history
+        if coin.price_change_24h is not None
+    ]
+    volume_changes = [
+        coin.volume_change_pct_24h
+        for coin in history
+        if coin.volume_change_pct_24h is not None
+    ]
+    observation_count = len(history)
+
+    if observation_count < _MIN_OBSERVATIONS_TO_SCORE:
+        price_persistence_score = 0
+        volume_confirmation_score = 0
+        attention_persistence_score = 0
+        breadth_alignment_score = 0
+    else:
+        price_persistence_score = _score_price_persistence(price_changes)
+        trend_sign = _sign(
+            price_persistence_score,
+            fallback=latest_coin.price_change_24h,
+        )
+        volume_confirmation_score = _score_volume_confirmation(
+            trend_sign=trend_sign,
+            volume_changes=volume_changes,
+        )
+        attention_persistence_score = _score_attention_persistence(history)
+        breadth_alignment_score = _score_breadth_alignment(history)
+    total_score = (
+        price_persistence_score
+        + volume_confirmation_score
+        + attention_persistence_score
+        + breadth_alignment_score
+    )
+
+    flags = []
+    expected_observations = EXPECTED_OBSERVATIONS_BY_WINDOW[window_label]
+    if observation_count < max(2, expected_observations // 2):
+        flags.append('thin-history')
+    if latest_snapshot.run.sentiment_now_value is not None:
+        if latest_snapshot.run.sentiment_now_value >= 55:
+            flags.append('risk-on')
+        elif latest_snapshot.run.sentiment_now_value <= 45:
+            flags.append('risk-off')
+    if latest_coin.is_watchlist:
+        flags.append('watchlist')
+
+    reason_tags = _build_reason_tags(
+        price_persistence_score=price_persistence_score,
+        volume_confirmation_score=volume_confirmation_score,
+        attention_persistence_score=attention_persistence_score,
+        breadth_alignment_score=breadth_alignment_score,
+        flags=flags,
+    )
+
+    return CryptoSignalCandidate(
+        coin_id=latest_coin.coin_id,
+        symbol=latest_coin.symbol,
+        name=latest_coin.name,
+        latest_price_usd=latest_coin.price_usd,
+        latest_price_change_24h=latest_coin.price_change_24h,
+        latest_volume_change_pct_24h=latest_coin.volume_change_pct_24h,
+        latest_context_tags=latest_coin.context_tags,
+        score=total_score,
+        price_persistence_score=price_persistence_score,
+        volume_confirmation_score=volume_confirmation_score,
+        attention_persistence_score=attention_persistence_score,
+        breadth_alignment_score=breadth_alignment_score,
+        observation_count=observation_count,
+        reason_tags=reason_tags,
+        flags=tuple(flags),
+        is_watchlist=latest_coin.is_watchlist,
+    )
+
+
+def _score_price_persistence(price_changes: list[float]) -> int:
+    if len(price_changes) == 0:
+        return 0
+
+    positive_hits = len([change for change in price_changes if change > 0])
+    negative_hits = len([change for change in price_changes if change < 0])
+    balance = (positive_hits - negative_hits) / len(price_changes)
+    average_change = mean(price_changes)
+    average_component = _clamp(average_change / 15.0, -1.0, 1.0)
+    return int(round(_clamp((balance * 0.7 + average_component * 0.3) * 4, -4, 4)))
+
+
+def _score_volume_confirmation(
+    trend_sign: int,
+    volume_changes: list[float],
+) -> int:
+    if trend_sign == 0 or len(volume_changes) == 0:
+        return 0
+
+    volume_support = _clamp(mean(volume_changes) / 30.0, -1.0, 1.0)
+    return int(round(_clamp(trend_sign * volume_support * 2, -2, 2)))
+
+
+def _score_attention_persistence(history: list[CryptoSignalCoinSnapshot]) -> int:
+    if len(history) == 0:
+        return 0
+
+    positive_hits = len(
+        [
+            coin for coin in history
+            if any(tag in _POSITIVE_ATTENTION_TAGS for tag in coin.context_tags)
+        ]
+    )
+    negative_hits = len(
+        [
+            coin for coin in history
+            if any(tag in _NEGATIVE_ATTENTION_TAGS for tag in coin.context_tags)
+        ]
+    )
+    balance = (positive_hits - negative_hits) / len(history)
+    return int(round(_clamp(balance * 2, -2, 2)))
+
+
+def _score_breadth_alignment(history: list[CryptoSignalCoinSnapshot]) -> int:
+    if len(history) == 0:
+        return 0
+
+    strongest_leader_hits = len(
+        [
+            coin for coin in history
+            if 'sector_leader_strongest' in coin.context_tags
+        ]
+    )
+    weakest_loser_hits = len(
+        [
+            coin for coin in history
+            if 'sector_loser_weakest' in coin.context_tags
+        ]
+    )
+    balance = (strongest_leader_hits - weakest_loser_hits) / len(history)
+    return int(round(_clamp(balance, -1, 1)))
+
+
+def _classify_market_regime(
+    latest_snapshot: CryptoSignalSnapshot,
+) -> tuple[str, str]:
+    sentiment_value = latest_snapshot.run.sentiment_now_value
+    strongest_change = latest_snapshot.run.strongest_sector_avg_price_change_24h
+    weakest_change = latest_snapshot.run.weakest_sector_avg_price_change_24h
+
+    if sentiment_value is None:
+        return 'Mixed', 'sentiment data unavailable'
+    if sentiment_value >= 55 and (strongest_change is None or strongest_change > 0):
+        return (
+            'Risk-on bias',
+            f'sentiment {sentiment_value:.0f} with strongest sector {strongest_change or 0:+.1f}%',
+        )
+    if sentiment_value <= 45 and (weakest_change is None or weakest_change < 0):
+        return (
+            'Risk-off bias',
+            f'sentiment {sentiment_value:.0f} with weakest sector {weakest_change or 0:+.1f}%',
+        )
+    return (
+        'Mixed',
+        f'sentiment {sentiment_value:.0f}, strongest {strongest_change or 0:+.1f}%, weakest {weakest_change or 0:+.1f}%',
+    )
+
+
+def _sign(value: int, fallback: float | None) -> int:
+    if value > 0:
+        return 1
+    if value < 0:
+        return -1
+    if fallback is None:
+        return 0
+    if fallback > 0:
+        return 1
+    if fallback < 0:
+        return -1
+    return 0
+
+
+def _clamp(value: float, lower: float, upper: float) -> float:
+    return max(lower, min(value, upper))
+
+
+def _build_reason_tags(
+    price_persistence_score: int,
+    volume_confirmation_score: int,
+    attention_persistence_score: int,
+    breadth_alignment_score: int,
+    flags: list[str],
+) -> tuple[str, ...]:
+    reason_tags = []
+    if price_persistence_score > 0:
+        reason_tags.append('price-up-persistent')
+    elif price_persistence_score < 0:
+        reason_tags.append('price-down-persistent')
+    if volume_confirmation_score != 0:
+        reason_tags.append('vol-confirm')
+    if attention_persistence_score != 0:
+        reason_tags.append('spotlight-repeat')
+    if breadth_alignment_score != 0:
+        reason_tags.append('breadth-align')
+    if 'risk-on' in flags:
+        reason_tags.append('risk-on')
+    if 'risk-off' in flags:
+        reason_tags.append('risk-off')
+    if 'thin-history' in flags:
+        reason_tags.append('thin-history')
+    return tuple(reason_tags)

--- a/src/service/crypto_signal/snapshot_builder.py
+++ b/src/service/crypto_signal/snapshot_builder.py
@@ -1,0 +1,360 @@
+import datetime
+from collections import OrderedDict
+from statistics import mean
+from typing import Iterable
+
+from market_data_library.types import cmc_type
+
+from src.job.crypto.crypto_digest_formatter import (
+    _find_sector_detail,
+    _is_same_sector,
+    _select_sector_coins,
+    should_emit_sector_detail_message,
+)
+from src.runtime.runtime_mode import RuntimeMode
+from src.service.crypto_signal.models import (
+    CryptoSignalCoinSnapshot,
+    CryptoSignalRunRecord,
+    CryptoSignalSnapshot,
+)
+from src.service.crypto_signal.repository import SNAPSHOT_VERSION
+from src.type.sentiment import FearGreedResult
+
+
+CONTEXT_TAG_ORDER = (
+    'spotlight_trending',
+    'spotlight_gainer',
+    'spotlight_loser',
+    'sector_leader_strongest',
+    'sector_loser_strongest',
+    'sector_leader_weakest',
+    'sector_loser_weakest',
+    'watchlist',
+)
+
+_SPOTLIGHT_REASON_TO_TAG = {
+    'trending': 'spotlight_trending',
+    'top gainer': 'spotlight_gainer',
+    'top loser': 'spotlight_loser',
+}
+
+
+def build_snapshot(
+    current: datetime.datetime,
+    runtime_mode: RuntimeMode,
+    source_name: str,
+    sentiment: FearGreedResult | None,
+    strongest_sector: cmc_type.Sector24hChange | None,
+    weakest_sector: cmc_type.Sector24hChange | None,
+    standout_entries: list[tuple[cmc_type.TrendingList, list[str]]],
+    standout_coin_details: dict[int, cmc_type.CoinDetail],
+    sector_details: dict[str, cmc_type.SectorDetail],
+    sector_detail_coin_details: dict[int, cmc_type.CoinDetail],
+    tracked_universe_entries: list[tuple[str, int]],
+    tracked_universe_coin_details: dict[int, cmc_type.CoinDetail],
+    watchlist_entries: list[tuple[str, int]],
+) -> CryptoSignalSnapshot:
+    run = CryptoSignalRunRecord(
+        run_timestamp_utc=current.astimezone(datetime.timezone.utc),
+        runtime_mode='test' if runtime_mode.is_test_mode else 'prod',
+        source_name=source_name,
+        snapshot_version=SNAPSHOT_VERSION,
+        sentiment_now_value=_sentiment_value(sentiment, label='Now'),
+        sentiment_now_label=_sentiment_label(sentiment, label='Now'),
+        sentiment_yesterday_value=_sentiment_value(sentiment, label='Yesterday'),
+        sentiment_last_week_value=_sentiment_value(sentiment, label='Last week'),
+        sentiment_7d_avg=_sentiment_average(sentiment, timeframe='7d'),
+        sentiment_30d_avg=_sentiment_average(sentiment, timeframe='30d'),
+        strongest_sector_id=_sector_attr(strongest_sector, 'sectorId'),
+        strongest_sector_name=_sector_attr(strongest_sector, 'title'),
+        strongest_sector_avg_price_change_24h=_sector_attr(
+            strongest_sector, 'avgPriceChange'
+        ),
+        strongest_sector_market_change_24h=_sector_attr(
+            strongest_sector, 'marketChange'
+        ),
+        strongest_sector_volume_change_24h=_sector_attr(
+            strongest_sector, 'volumeChange'
+        ),
+        strongest_sector_gainers_num=_safe_int(_sector_attr(strongest_sector, 'gainersNum')),
+        strongest_sector_losers_num=_safe_int(_sector_attr(strongest_sector, 'losersNum')),
+        weakest_sector_id=_sector_attr(weakest_sector, 'sectorId'),
+        weakest_sector_name=_sector_attr(weakest_sector, 'title'),
+        weakest_sector_avg_price_change_24h=_sector_attr(
+            weakest_sector, 'avgPriceChange'
+        ),
+        weakest_sector_market_change_24h=_sector_attr(weakest_sector, 'marketChange'),
+        weakest_sector_volume_change_24h=_sector_attr(weakest_sector, 'volumeChange'),
+        weakest_sector_gainers_num=_safe_int(_sector_attr(weakest_sector, 'gainersNum')),
+        weakest_sector_losers_num=_safe_int(_sector_attr(weakest_sector, 'losersNum')),
+    )
+
+    merged_coins: OrderedDict[int, CryptoSignalCoinSnapshot] = OrderedDict()
+
+    for coin, reasons in standout_entries:
+        _upsert_coin(
+            merged_coins=merged_coins,
+            coin_id=coin.id,
+            symbol=coin.symbol,
+            name=coin.name,
+            price_usd=coin.priceChange.price,
+            price_change_24h=coin.priceChange.priceChange24h,
+            volume_24h=coin.priceChange.volume24h,
+            volume_change_pct_24h=(
+                standout_coin_details.get(coin.id).volumeChangePercentage24h
+                if coin.id in standout_coin_details
+                else None
+            ),
+            is_watchlist=False,
+            context_tags=[
+                _SPOTLIGHT_REASON_TO_TAG[reason]
+                for reason in reasons
+                if reason in _SPOTLIGHT_REASON_TO_TAG
+            ],
+        )
+
+    if should_emit_sector_detail_message(
+        strongest_sector=strongest_sector,
+        weakest_sector=weakest_sector,
+        sector_details=sector_details,
+    ):
+        _merge_sector_context(
+            merged_coins=merged_coins,
+            sector=strongest_sector,
+            sector_detail=_find_sector_detail(strongest_sector, sector_details),
+            sector_detail_coin_details=sector_detail_coin_details,
+            leader_tag='sector_leader_strongest',
+            loser_tag='sector_loser_strongest',
+        )
+        if not _is_same_sector(strongest_sector, weakest_sector):
+            _merge_sector_context(
+                merged_coins=merged_coins,
+                sector=weakest_sector,
+                sector_detail=_find_sector_detail(weakest_sector, sector_details),
+                sector_detail_coin_details=sector_detail_coin_details,
+                leader_tag='sector_leader_weakest',
+                loser_tag='sector_loser_weakest',
+            )
+
+    watchlist_ids = {coin_id for _symbol, coin_id in watchlist_entries}
+    for symbol, coin_id in tracked_universe_entries:
+        coin_detail = tracked_universe_coin_details.get(coin_id)
+        if coin_detail is None:
+            continue
+        _upsert_coin(
+            merged_coins=merged_coins,
+            coin_id=coin_id,
+            symbol=symbol or coin_detail.symbol,
+            name=coin_detail.name,
+            price_usd=_coin_detail_price(coin_detail),
+            price_change_24h=_coin_detail_price_change(coin_detail),
+            volume_24h=coin_detail.volume,
+            volume_change_pct_24h=coin_detail.volumeChangePercentage24h,
+            is_watchlist=coin_id in watchlist_ids,
+            context_tags=['watchlist'] if coin_id in watchlist_ids else [],
+        )
+
+    return CryptoSignalSnapshot(
+        run=run,
+        coins=sorted(
+            merged_coins.values(),
+            key=lambda coin: (coin.symbol, coin.coin_id),
+        ),
+    )
+
+
+def _merge_sector_context(
+    merged_coins: OrderedDict[int, CryptoSignalCoinSnapshot],
+    sector: cmc_type.Sector24hChange | None,
+    sector_detail: cmc_type.SectorDetail | None,
+    sector_detail_coin_details: dict[int, cmc_type.CoinDetail],
+    leader_tag: str,
+    loser_tag: str,
+) -> None:
+    if sector is None or sector_detail is None:
+        return
+
+    leaders = _select_sector_coins(
+        sector_detail=sector_detail,
+        direction='leaders',
+        limit=2,
+        require_threshold=False,
+    )
+    losers = _select_sector_coins(
+        sector_detail=sector_detail,
+        direction='losers',
+        limit=2,
+        require_threshold=False,
+    )
+    for coin in leaders:
+        _merge_sector_coin(
+            merged_coins=merged_coins,
+            coin=coin,
+            coin_detail=sector_detail_coin_details.get(coin.id),
+            context_tag=leader_tag,
+        )
+    for coin in losers:
+        _merge_sector_coin(
+            merged_coins=merged_coins,
+            coin=coin,
+            coin_detail=sector_detail_coin_details.get(coin.id),
+            context_tag=loser_tag,
+        )
+
+
+def _merge_sector_coin(
+    merged_coins: OrderedDict[int, CryptoSignalCoinSnapshot],
+    coin: cmc_type.SectorCoin,
+    coin_detail: cmc_type.CoinDetail | None,
+    context_tag: str,
+) -> None:
+    quote = next(iter(coin.quote.values())) if coin.quote else None
+    _upsert_coin(
+        merged_coins=merged_coins,
+        coin_id=coin.id,
+        symbol=coin.symbol,
+        name=coin.name,
+        price_usd=(
+            _coin_detail_price(coin_detail)
+            if coin_detail is not None
+            else getattr(quote, 'price', None)
+        ),
+        price_change_24h=(
+            _coin_detail_price_change(coin_detail)
+            if coin_detail is not None
+            else getattr(quote, 'percent_change_24h', None)
+        ),
+        volume_24h=(
+            coin_detail.volume if coin_detail is not None else getattr(quote, 'volume_24h', None)
+        ),
+        volume_change_pct_24h=(
+            coin_detail.volumeChangePercentage24h if coin_detail is not None else None
+        ),
+        is_watchlist=False,
+        context_tags=[context_tag],
+    )
+
+
+def _upsert_coin(
+    merged_coins: OrderedDict[int, CryptoSignalCoinSnapshot],
+    coin_id: int,
+    symbol: str,
+    name: str,
+    price_usd: float | None,
+    price_change_24h: float | None,
+    volume_24h: float | None,
+    volume_change_pct_24h: float | None,
+    is_watchlist: bool,
+    context_tags: Iterable[str],
+) -> None:
+    existing = merged_coins.get(coin_id)
+    normalized_tags = _normalize_context_tags(context_tags)
+    if existing is None:
+        merged_coins[coin_id] = CryptoSignalCoinSnapshot(
+            coin_id=coin_id,
+            symbol=symbol,
+            name=name,
+            price_usd=price_usd,
+            price_change_24h=price_change_24h,
+            volume_24h=volume_24h,
+            volume_change_pct_24h=volume_change_pct_24h,
+            is_watchlist=is_watchlist,
+            context_tags=normalized_tags,
+        )
+        return
+
+    merged_coins[coin_id] = CryptoSignalCoinSnapshot(
+        coin_id=coin_id,
+        symbol=existing.symbol or symbol,
+        name=existing.name or name,
+        price_usd=existing.price_usd if existing.price_usd is not None else price_usd,
+        price_change_24h=(
+            existing.price_change_24h
+            if existing.price_change_24h is not None
+            else price_change_24h
+        ),
+        volume_24h=existing.volume_24h if existing.volume_24h is not None else volume_24h,
+        volume_change_pct_24h=(
+            existing.volume_change_pct_24h
+            if existing.volume_change_pct_24h is not None
+            else volume_change_pct_24h
+        ),
+        is_watchlist=existing.is_watchlist or is_watchlist,
+        context_tags=_normalize_context_tags((*existing.context_tags, *normalized_tags)),
+    )
+
+
+def _normalize_context_tags(tags: Iterable[str]) -> tuple[str, ...]:
+    seen_tags = {tag for tag in tags if tag}
+    return tuple(tag for tag in CONTEXT_TAG_ORDER if tag in seen_tags)
+
+
+def _sentiment_value(
+    sentiment: FearGreedResult | None,
+    label: str,
+) -> float | None:
+    point = _find_sentiment_point(sentiment, label=label)
+    return float(point.value) if point is not None else None
+
+
+def _sentiment_label(
+    sentiment: FearGreedResult | None,
+    label: str,
+) -> str | None:
+    point = _find_sentiment_point(sentiment, label=label)
+    return point.sentiment_text if point is not None else None
+
+
+def _sentiment_average(
+    sentiment: FearGreedResult | None,
+    timeframe: str,
+) -> float | None:
+    if sentiment is None:
+        return None
+    matches = [
+        average.value
+        for average in sentiment.average
+        if average.timeframe == timeframe
+    ]
+    if len(matches) == 0:
+        return None
+    return float(mean(matches))
+
+
+def _find_sentiment_point(
+    sentiment: FearGreedResult | None,
+    label: str,
+):
+    if sentiment is None:
+        return None
+    for point in sentiment.data:
+        if point.relative_date_text == label:
+            return point
+    return None
+
+
+def _sector_attr(
+    sector: cmc_type.Sector24hChange | None,
+    attr_name: str,
+):
+    if sector is None:
+        return None
+    return getattr(sector, attr_name)
+
+
+def _safe_int(value) -> int | None:
+    if value in (None, ''):
+        return None
+    return int(value)
+
+
+def _coin_detail_price(coin_detail: cmc_type.CoinDetail | None) -> float | None:
+    if coin_detail is None:
+        return None
+    return coin_detail.statistics.price
+
+
+def _coin_detail_price_change(coin_detail: cmc_type.CoinDetail | None) -> float | None:
+    if coin_detail is None:
+        return None
+    return coin_detail.statistics.priceChangePercentage24h

--- a/src/service/crypto_signal/snapshot_builder.py
+++ b/src/service/crypto_signal/snapshot_builder.py
@@ -232,6 +232,8 @@ def _merge_sector_coin(
     context_tag: str,
 ) -> None:
     quote = next(iter(coin.quote.values())) if coin.quote else None
+    # Prefer the detail fetch because it carries the richer fields used for
+    # scoring; the sector-list quote is only a fallback when detail is missing.
     _upsert_coin(
         merged_coins=merged_coins,
         coin_id=coin.id,
@@ -302,8 +304,9 @@ def _upsert_coin(
         return
 
     existing_snapshot = existing.snapshot
-    # Evidence is additive, but scalar values should come from the most
-    # authoritative source available for the coin in this run.
+    # Evidence is additive, but each scalar keeps its own source because a
+    # single coin snapshot can be assembled from list payloads, sector detail,
+    # and tracked-universe detail with different completeness per field.
     merged_symbol, symbol_source = _select_scalar(
         existing_value=existing_snapshot.symbol,
         existing_source=existing.symbol_source,

--- a/src/service/crypto_signal/snapshot_builder.py
+++ b/src/service/crypto_signal/snapshot_builder.py
@@ -1,7 +1,9 @@
 import datetime
 from collections import OrderedDict
+from dataclasses import dataclass
+from enum import IntEnum
 from statistics import mean
-from typing import Iterable
+from typing import Iterable, TypeVar
 
 from market_data_library.types import cmc_type
 
@@ -37,6 +39,25 @@ _SPOTLIGHT_REASON_TO_TAG = {
     'top gainer': 'spotlight_gainer',
     'top loser': 'spotlight_loser',
 }
+
+_ScalarValue = TypeVar('_ScalarValue')
+
+
+class _CoinSnapshotSource(IntEnum):
+    LIST_PAYLOAD = 1
+    SECTOR_DETAIL = 2
+    TRACKED_UNIVERSE = 3
+
+
+@dataclass(slots=True)
+class _MergedCoin:
+    snapshot: CryptoSignalCoinSnapshot
+    symbol_source: _CoinSnapshotSource
+    name_source: _CoinSnapshotSource
+    price_usd_source: _CoinSnapshotSource
+    price_change_24h_source: _CoinSnapshotSource
+    volume_24h_source: _CoinSnapshotSource
+    volume_change_pct_24h_source: _CoinSnapshotSource
 
 
 def build_snapshot(
@@ -89,7 +110,7 @@ def build_snapshot(
         weakest_sector_losers_num=_safe_int(_sector_attr(weakest_sector, 'losersNum')),
     )
 
-    merged_coins: OrderedDict[int, CryptoSignalCoinSnapshot] = OrderedDict()
+    merged_coins: OrderedDict[int, _MergedCoin] = OrderedDict()
 
     for coin, reasons in standout_entries:
         _upsert_coin(
@@ -111,6 +132,7 @@ def build_snapshot(
                 for reason in reasons
                 if reason in _SPOTLIGHT_REASON_TO_TAG
             ],
+            source=_CoinSnapshotSource.LIST_PAYLOAD,
         )
 
     if should_emit_sector_detail_message(
@@ -144,7 +166,7 @@ def build_snapshot(
         _upsert_coin(
             merged_coins=merged_coins,
             coin_id=coin_id,
-            symbol=symbol or coin_detail.symbol,
+            symbol=coin_detail.symbol or symbol,
             name=coin_detail.name,
             price_usd=_coin_detail_price(coin_detail),
             price_change_24h=_coin_detail_price_change(coin_detail),
@@ -152,19 +174,20 @@ def build_snapshot(
             volume_change_pct_24h=coin_detail.volumeChangePercentage24h,
             is_watchlist=coin_id in watchlist_ids,
             context_tags=['watchlist'] if coin_id in watchlist_ids else [],
+            source=_CoinSnapshotSource.TRACKED_UNIVERSE,
         )
 
     return CryptoSignalSnapshot(
         run=run,
         coins=sorted(
-            merged_coins.values(),
+            [merged_coin.snapshot for merged_coin in merged_coins.values()],
             key=lambda coin: (coin.symbol, coin.coin_id),
         ),
     )
 
 
 def _merge_sector_context(
-    merged_coins: OrderedDict[int, CryptoSignalCoinSnapshot],
+    merged_coins: OrderedDict[int, _MergedCoin],
     sector: cmc_type.Sector24hChange | None,
     sector_detail: cmc_type.SectorDetail | None,
     sector_detail_coin_details: dict[int, cmc_type.CoinDetail],
@@ -203,7 +226,7 @@ def _merge_sector_context(
 
 
 def _merge_sector_coin(
-    merged_coins: OrderedDict[int, CryptoSignalCoinSnapshot],
+    merged_coins: OrderedDict[int, _MergedCoin],
     coin: cmc_type.SectorCoin,
     coin_detail: cmc_type.CoinDetail | None,
     context_tag: str,
@@ -232,11 +255,16 @@ def _merge_sector_coin(
         ),
         is_watchlist=False,
         context_tags=[context_tag],
+        source=(
+            _CoinSnapshotSource.SECTOR_DETAIL
+            if coin_detail is not None
+            else _CoinSnapshotSource.LIST_PAYLOAD
+        ),
     )
 
 
 def _upsert_coin(
-    merged_coins: OrderedDict[int, CryptoSignalCoinSnapshot],
+    merged_coins: OrderedDict[int, _MergedCoin],
     coin_id: int,
     symbol: str,
     name: str,
@@ -246,11 +274,12 @@ def _upsert_coin(
     volume_change_pct_24h: float | None,
     is_watchlist: bool,
     context_tags: Iterable[str],
+    source: _CoinSnapshotSource,
 ) -> None:
     existing = merged_coins.get(coin_id)
     normalized_tags = _normalize_context_tags(context_tags)
     if existing is None:
-        merged_coins[coin_id] = CryptoSignalCoinSnapshot(
+        snapshot = CryptoSignalCoinSnapshot(
             coin_id=coin_id,
             symbol=symbol,
             name=name,
@@ -261,27 +290,102 @@ def _upsert_coin(
             is_watchlist=is_watchlist,
             context_tags=normalized_tags,
         )
+        merged_coins[coin_id] = _MergedCoin(
+            snapshot=snapshot,
+            symbol_source=source,
+            name_source=source,
+            price_usd_source=source,
+            price_change_24h_source=source,
+            volume_24h_source=source,
+            volume_change_pct_24h_source=source,
+        )
         return
 
-    merged_coins[coin_id] = CryptoSignalCoinSnapshot(
-        coin_id=coin_id,
-        symbol=existing.symbol or symbol,
-        name=existing.name or name,
-        price_usd=existing.price_usd if existing.price_usd is not None else price_usd,
-        price_change_24h=(
-            existing.price_change_24h
-            if existing.price_change_24h is not None
-            else price_change_24h
-        ),
-        volume_24h=existing.volume_24h if existing.volume_24h is not None else volume_24h,
-        volume_change_pct_24h=(
-            existing.volume_change_pct_24h
-            if existing.volume_change_pct_24h is not None
-            else volume_change_pct_24h
-        ),
-        is_watchlist=existing.is_watchlist or is_watchlist,
-        context_tags=_normalize_context_tags((*existing.context_tags, *normalized_tags)),
+    existing_snapshot = existing.snapshot
+    # Evidence is additive, but scalar values should come from the most
+    # authoritative source available for the coin in this run.
+    merged_symbol, symbol_source = _select_scalar(
+        existing_value=existing_snapshot.symbol,
+        existing_source=existing.symbol_source,
+        new_value=symbol,
+        new_source=source,
     )
+    merged_name, name_source = _select_scalar(
+        existing_value=existing_snapshot.name,
+        existing_source=existing.name_source,
+        new_value=name,
+        new_source=source,
+    )
+    merged_price_usd, price_usd_source = _select_scalar(
+        existing_value=existing_snapshot.price_usd,
+        existing_source=existing.price_usd_source,
+        new_value=price_usd,
+        new_source=source,
+    )
+    merged_price_change_24h, price_change_24h_source = _select_scalar(
+        existing_value=existing_snapshot.price_change_24h,
+        existing_source=existing.price_change_24h_source,
+        new_value=price_change_24h,
+        new_source=source,
+    )
+    merged_volume_24h, volume_24h_source = _select_scalar(
+        existing_value=existing_snapshot.volume_24h,
+        existing_source=existing.volume_24h_source,
+        new_value=volume_24h,
+        new_source=source,
+    )
+    (
+        merged_volume_change_pct_24h,
+        volume_change_pct_24h_source,
+    ) = _select_scalar(
+        existing_value=existing_snapshot.volume_change_pct_24h,
+        existing_source=existing.volume_change_pct_24h_source,
+        new_value=volume_change_pct_24h,
+        new_source=source,
+    )
+
+    merged_coins[coin_id] = _MergedCoin(
+        snapshot=CryptoSignalCoinSnapshot(
+            coin_id=coin_id,
+            symbol=merged_symbol,
+            name=merged_name,
+            price_usd=merged_price_usd,
+            price_change_24h=merged_price_change_24h,
+            volume_24h=merged_volume_24h,
+            volume_change_pct_24h=merged_volume_change_pct_24h,
+            is_watchlist=existing_snapshot.is_watchlist or is_watchlist,
+            context_tags=_normalize_context_tags(
+                (*existing_snapshot.context_tags, *normalized_tags)
+            ),
+        ),
+        symbol_source=symbol_source,
+        name_source=name_source,
+        price_usd_source=price_usd_source,
+        price_change_24h_source=price_change_24h_source,
+        volume_24h_source=volume_24h_source,
+        volume_change_pct_24h_source=volume_change_pct_24h_source,
+    )
+
+
+def _select_scalar(
+    existing_value: _ScalarValue,
+    existing_source: _CoinSnapshotSource,
+    new_value: _ScalarValue,
+    new_source: _CoinSnapshotSource,
+) -> tuple[_ScalarValue, _CoinSnapshotSource]:
+    if not _has_scalar_value(new_value):
+        return existing_value, existing_source
+    if not _has_scalar_value(existing_value) or new_source > existing_source:
+        return new_value, new_source
+    return existing_value, existing_source
+
+
+def _has_scalar_value(value: object) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value != ''
+    return True
 
 
 def _normalize_context_tags(tags: Iterable[str]) -> tuple[str, ...]:

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -146,3 +146,72 @@ def test_telegram_timeout_getters_require_positive_numbers(
         match=f'{env_name} must be a positive number',
     ):
         getter()
+
+
+def test_crypto_signal_db_path_defaults_to_var_sqlite(monkeypatch):
+    monkeypatch.delenv('CRYPTO_SIGNAL_DB_PATH', raising=False)
+
+    assert config.get_crypto_signal_db_path() == 'var/crypto_signal/crypto_signal.sqlite3'
+
+
+def test_crypto_signal_recipient_id_defaults_to_crypto_admin(monkeypatch):
+    monkeypatch.delenv('CRYPTO_SIGNAL_RECIPIENT_ID', raising=False)
+    monkeypatch.setattr(config, 'get_telegram_crypto_admin_id', lambda: 'crypto-admin')
+
+    assert config.get_crypto_signal_recipient_id() == 'crypto-admin'
+
+
+def test_crypto_signal_tracked_universe_defaults(monkeypatch):
+    monkeypatch.delenv('CRYPTO_SIGNAL_TRACKED_UNIVERSE', raising=False)
+
+    assert config.get_crypto_signal_tracked_universe() == [
+        ('BTC', 1),
+        ('ETH', 1027),
+        ('SOL', 5426),
+    ]
+
+
+def test_crypto_signal_tracked_universe_supports_explicit_coin_ids(monkeypatch):
+    monkeypatch.setenv('CRYPTO_SIGNAL_TRACKED_UNIVERSE', 'BTC,TAO:22974')
+
+    assert config.get_crypto_signal_tracked_universe() == [
+        ('BTC', 1),
+        ('TAO', 22974),
+    ]
+
+
+def test_crypto_signal_tracked_universe_rejects_unknown_symbol_without_id(
+    monkeypatch,
+):
+    monkeypatch.setenv('CRYPTO_SIGNAL_TRACKED_UNIVERSE', 'TAO')
+
+    with pytest.raises(
+        RuntimeError,
+        match='CRYPTO_SIGNAL_TRACKED_UNIVERSE unqualified symbols must use a known default id or the SYMBOL:ID form',
+    ):
+        config.get_crypto_signal_tracked_universe()
+
+
+def test_crypto_signal_watchlist_defaults_to_empty(monkeypatch):
+    monkeypatch.delenv('CRYPTO_SIGNAL_WATCHLIST', raising=False)
+
+    assert config.get_crypto_signal_watchlist() == []
+
+
+def test_crypto_signal_watchlist_supports_explicit_coin_ids(monkeypatch):
+    monkeypatch.setenv('CRYPTO_SIGNAL_WATCHLIST', 'BTC,TAO:22974')
+
+    assert config.get_crypto_signal_watchlist() == [
+        ('BTC', 1),
+        ('TAO', 22974),
+    ]
+
+
+def test_crypto_signal_watchlist_rejects_unknown_symbol_without_id(monkeypatch):
+    monkeypatch.setenv('CRYPTO_SIGNAL_WATCHLIST', 'TAO')
+
+    with pytest.raises(
+        RuntimeError,
+        match='CRYPTO_SIGNAL_WATCHLIST unqualified symbols must use a known default id or the SYMBOL:ID form',
+    ):
+        config.get_crypto_signal_watchlist()

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 from src.config import config
+from src.runtime.runtime_mode import RuntimeMode
 
 
 def test_get_selenium_server_host_returns_host_for_remote_mode(monkeypatch):
@@ -150,8 +151,30 @@ def test_telegram_timeout_getters_require_positive_numbers(
 
 def test_crypto_signal_db_path_defaults_to_var_sqlite(monkeypatch):
     monkeypatch.delenv('CRYPTO_SIGNAL_DB_PATH', raising=False)
+    monkeypatch.delenv('CRYPTO_SIGNAL_TEST_DB_PATH', raising=False)
 
     assert config.get_crypto_signal_db_path() == 'var/crypto_signal/crypto_signal.sqlite3'
+
+
+def test_crypto_signal_db_path_uses_test_default_in_test_mode(monkeypatch):
+    monkeypatch.delenv('CRYPTO_SIGNAL_DB_PATH', raising=False)
+    monkeypatch.delenv('CRYPTO_SIGNAL_TEST_DB_PATH', raising=False)
+
+    assert config.get_crypto_signal_db_path(
+        runtime_mode=RuntimeMode.from_test_mode(True)
+    ) == 'var/crypto_signal/crypto_signal.test.sqlite3'
+
+
+def test_crypto_signal_db_path_allows_explicit_test_override(monkeypatch):
+    monkeypatch.setenv('CRYPTO_SIGNAL_DB_PATH', 'var/crypto_signal/custom.sqlite3')
+    monkeypatch.setenv(
+        'CRYPTO_SIGNAL_TEST_DB_PATH',
+        'var/crypto_signal/custom.test.sqlite3',
+    )
+
+    assert config.get_crypto_signal_db_path(
+        runtime_mode=RuntimeMode.from_test_mode(True)
+    ) == 'var/crypto_signal/custom.test.sqlite3'
 
 
 def test_crypto_signal_recipient_id_defaults_to_crypto_admin(monkeypatch):
@@ -215,3 +238,46 @@ def test_crypto_signal_watchlist_rejects_unknown_symbol_without_id(monkeypatch):
         match='CRYPTO_SIGNAL_WATCHLIST unqualified symbols must use a known default id or the SYMBOL:ID form',
     ):
         config.get_crypto_signal_watchlist()
+
+
+def test_crypto_signal_dynamic_candidate_min_price_usd_defaults(monkeypatch):
+    monkeypatch.delenv('CRYPTO_SIGNAL_DYNAMIC_CANDIDATE_MIN_PRICE_USD', raising=False)
+
+    assert config.get_crypto_signal_dynamic_candidate_min_price_usd() == 0.0
+
+
+def test_crypto_signal_dynamic_candidate_min_volume_24h_defaults(monkeypatch):
+    monkeypatch.delenv(
+        'CRYPTO_SIGNAL_DYNAMIC_CANDIDATE_MIN_VOLUME_24H',
+        raising=False,
+    )
+
+    assert config.get_crypto_signal_dynamic_candidate_min_volume_24h() == 50_000_000.0
+
+
+@pytest.mark.parametrize(
+    ('getter_name', 'env_name'),
+    [
+        (
+            'get_crypto_signal_dynamic_candidate_min_price_usd',
+            'CRYPTO_SIGNAL_DYNAMIC_CANDIDATE_MIN_PRICE_USD',
+        ),
+        (
+            'get_crypto_signal_dynamic_candidate_min_volume_24h',
+            'CRYPTO_SIGNAL_DYNAMIC_CANDIDATE_MIN_VOLUME_24H',
+        ),
+    ],
+)
+def test_crypto_signal_dynamic_candidate_floors_reject_negative_values(
+    monkeypatch,
+    getter_name,
+    env_name,
+):
+    monkeypatch.setenv(env_name, '-1')
+    getter = getattr(config, getter_name)
+
+    with pytest.raises(
+        RuntimeError,
+        match=f'{env_name} must be a positive number',
+    ):
+        getter()

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -53,6 +53,21 @@ def test_get_selenium_server_host_allows_docker_only_chrome_host_in_container(
     assert config.get_selenium_server_host() == 'http://chrome:4444'
 
 
+def test_get_auth_exclude_endpoints_strips_blank_entries(monkeypatch):
+    monkeypatch.setenv('AUTH_EXCLUDE_ENDPOINTS', ' /healthz, ,/tradingview/daily-stocks,')
+
+    assert config.get_auth_exclude_endpoints() == [
+        '/healthz',
+        '/tradingview/daily-stocks',
+    ]
+
+
+def test_get_auth_exclude_endpoints_defaults_to_empty_list(monkeypatch):
+    monkeypatch.delenv('AUTH_EXCLUDE_ENDPOINTS', raising=False)
+
+    assert config.get_auth_exclude_endpoints() == []
+
+
 def test_get_cnn_page_load_timeout_seconds_defaults_to_45(monkeypatch):
     monkeypatch.delenv('CNN_PAGE_LOAD_TIMEOUT_SECONDS', raising=False)
 

--- a/tests/unit/dependencies_test.py
+++ b/tests/unit/dependencies_test.py
@@ -49,11 +49,10 @@ async def test_build_and_cleanup_wire_dependencies_without_live_clients(monkeypa
     barchart_service = Mock()
     barchart_service.cleanup = AsyncMock()
     stocks_sentiment_service = Mock()
-    cryptoquant_underlying_service = Mock()
-    cryptoquant_underlying_service.cleanup = AsyncMock()
-    cryptoquant_service = Mock(cryptoquant_service=cryptoquant_underlying_service)
+    cryptoquant_service = Mock()
     crypto_sentiment_service = Mock()
     crypto_stats_service = Mock()
+    cleanup_market_data_api = AsyncMock()
 
     build_http_client = AsyncMock(return_value=vix_http_client)
     tradingview_cls = Mock(return_value=tradingview_service)
@@ -88,6 +87,10 @@ async def test_build_and_cleanup_wire_dependencies_without_live_clients(monkeypa
         crypto_sentiment_cls,
     )
     monkeypatch.setattr("src.dependencies.CryptoStatsService", crypto_stats_cls)
+    monkeypatch.setattr(
+        "src.dependencies.cleanup_market_data_api",
+        cleanup_market_data_api,
+    )
 
     await Dependencies.build()
     await Dependencies.build()
@@ -112,12 +115,14 @@ async def test_build_and_cleanup_wire_dependencies_without_live_clients(monkeypa
     assert Dependencies.get_vix_central_service() is vix_central_service
     assert Dependencies.get_barchart_service() is barchart_service
     assert Dependencies.get_stocks_sentiment_service() is stocks_sentiment_service
-    assert Dependencies.get_cryptoquant_api_service() is cryptoquant_service
+    assert Dependencies.get_cryptoquant_api_service() is cryptoquant_cls.return_value
     assert Dependencies.get_crypto_sentiment_service() is crypto_sentiment_service
     assert Dependencies.get_crypto_stats_service() is crypto_stats_service
 
     await Dependencies.cleanup()
 
     vix_central_service.cleanup.assert_awaited_once()
-    barchart_service.cleanup.assert_awaited_once()
-    cryptoquant_underlying_service.cleanup.assert_awaited_once()
+    cleanup_market_data_api.assert_awaited_once()
+    assert Dependencies.is_initialised is False
+    assert Dependencies.get_crypto_sentiment_service() is None
+    assert Dependencies.get_crypto_stats_service() is None

--- a/tests/unit/job/crypto/crypto_digest_message_sender_test.py
+++ b/tests/unit/job/crypto/crypto_digest_message_sender_test.py
@@ -4,13 +4,14 @@ import datetime
 import json
 import os
 import typing
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from dacite import from_dict
 from market_data_library.types import cmc_type
 
 from src.job.crypto.crypto_digest_message_sender import CryptoDigestMessageSender
+from src.runtime.runtime_mode import DEFAULT_RUNTIME_MODE
 from src.type.sentiment import FearGreedAverage, FearGreedData, FearGreedResult
 
 
@@ -166,6 +167,10 @@ class TestCryptoDigestMessageSender:
         message_sender = object.__new__(CryptoDigestMessageSender)
         message_sender.cmc_service = AsyncMock()
         message_sender.sentiment_service = AsyncMock()
+        message_sender.signal_repository = Mock()
+        message_sender.tracked_universe_entries = [('BTC', 1), ('ETH', 1027), ('SOL', 5426)]
+        message_sender.watchlist_entries = [('BTC', 1), ('ETH', 1027), ('SOL', 5426)]
+        message_sender.runtime_mode = DEFAULT_RUNTIME_MODE
         return message_sender
 
     @pytest.mark.asyncio
@@ -258,6 +263,7 @@ class TestCryptoDigestMessageSender:
         assert 'volume change \\+161\\.37%' in message
         assert '• top gainer: *Cannation*' in message
         assert '24h \\+55\\.00% ❗' in message
+        message_sender.signal_repository.save_snapshot.assert_called_once()
         standout_section = message.split('*Standout coins*', maxsplit=1)[1]
         assert '7d ' not in standout_section
         assert 'mcap ' not in standout_section
@@ -561,3 +567,44 @@ class TestCryptoDigestMessageSender:
         assert 'price 0\\.0569' in message
         assert 'price 0\\.1253' in message
         assert '999999' not in message
+
+    @pytest.mark.asyncio
+    async def test_format_message_alerts_admin_when_snapshot_persistence_fails(
+        self,
+        monkeypatch,
+    ):
+        strongest_sector = copy.deepcopy(self.sector_24h_change[0])
+        strongest_sector.sectorId = 'video'
+
+        weakest_sector = copy.deepcopy(self.sector_24h_change[0])
+        weakest_sector.sectorId = 'defi'
+        weakest_sector.title = 'DeFi'
+        weakest_sector.avgPriceChange = -4.8
+
+        send_message_to_admin = AsyncMock()
+        monkeypatch.setattr(
+            'src.job.crypto.crypto_digest_message_sender.send_message_to_admin',
+            send_message_to_admin,
+        )
+
+        message_sender = self.build_message_sender()
+        message_sender.signal_repository.save_snapshot.side_effect = RuntimeError(
+            'sqlite unavailable'
+        )
+        message_sender.sentiment_service.get_crypto_fear_greed_index = AsyncMock(
+            return_value=self.sentiment
+        )
+        message_sender.cmc_service.get_sectors_24h_change = AsyncMock(
+            side_effect=[[strongest_sector], [weakest_sector]]
+        )
+        message_sender.cmc_service.get_spotlight = AsyncMock(return_value=self.spotlight)
+        message_sender.cmc_service.get_coin_detail = AsyncMock(return_value=self.coin_detail)
+        message_sender.cmc_service.get_sector_detail = AsyncMock(
+            side_effect=RuntimeError('403 Forbidden')
+        )
+
+        messages = await message_sender.format_message()
+
+        assert len(messages) == 1
+        send_message_to_admin.assert_awaited_once()
+        assert 'sqlite unavailable' in send_message_to_admin.await_args.kwargs['message']

--- a/tests/unit/job/crypto/crypto_digest_message_sender_test.py
+++ b/tests/unit/job/crypto/crypto_digest_message_sender_test.py
@@ -272,6 +272,7 @@ class TestCryptoDigestMessageSender:
         assert '• top gainer: *Cannation*' in message
         assert '24h \\+55\\.00% ❗' in message
         message_sender.signal_repository.save_snapshot.assert_called_once()
+        message_sender.signal_repository.init_schema.assert_called_once()
         message_sender.signal_backfill_service.build_snapshots.assert_awaited_once()
         standout_section = message.split('*Standout coins*', maxsplit=1)[1]
         assert '7d ' not in standout_section
@@ -309,6 +310,7 @@ class TestCryptoDigestMessageSender:
 
         await message_sender.format_message()
 
+        message_sender.signal_repository.init_schema.assert_called_once()
         message_sender.signal_backfill_service.build_snapshots.assert_awaited_once()
         coin_entries = (
             message_sender.signal_backfill_service.build_snapshots.await_args.kwargs[
@@ -354,6 +356,7 @@ class TestCryptoDigestMessageSender:
 
         assert len(messages) == 1
         assert '*Crypto market digest*' in messages[0]
+        message_sender.signal_repository.init_schema.assert_called_once()
         message_sender.signal_repository.save_snapshot.assert_called_once()
         message_sender.signal_backfill_service.build_snapshots.assert_not_awaited()
 

--- a/tests/unit/job/crypto/crypto_digest_message_sender_test.py
+++ b/tests/unit/job/crypto/crypto_digest_message_sender_test.py
@@ -168,6 +168,14 @@ class TestCryptoDigestMessageSender:
         message_sender.cmc_service = AsyncMock()
         message_sender.sentiment_service = AsyncMock()
         message_sender.signal_repository = Mock()
+        message_sender.signal_repository.get_coin_observation_counts_since = Mock(
+            return_value={}
+        )
+        message_sender.signal_repository.save_or_merge_snapshot = Mock()
+        message_sender.signal_backfill_service = AsyncMock()
+        message_sender.signal_backfill_service.build_snapshots = AsyncMock(
+            return_value=[]
+        )
         message_sender.tracked_universe_entries = [('BTC', 1), ('ETH', 1027), ('SOL', 5426)]
         message_sender.watchlist_entries = [('BTC', 1), ('ETH', 1027), ('SOL', 5426)]
         message_sender.runtime_mode = DEFAULT_RUNTIME_MODE
@@ -264,9 +272,90 @@ class TestCryptoDigestMessageSender:
         assert '• top gainer: *Cannation*' in message
         assert '24h \\+55\\.00% ❗' in message
         message_sender.signal_repository.save_snapshot.assert_called_once()
+        message_sender.signal_backfill_service.build_snapshots.assert_awaited_once()
         standout_section = message.split('*Standout coins*', maxsplit=1)[1]
         assert '7d ' not in standout_section
         assert 'mcap ' not in standout_section
+
+    @pytest.mark.asyncio
+    async def test_format_message_backfills_only_coins_without_stored_history(self):
+        strongest_sector = copy.deepcopy(self.sector_24h_change[0])
+        strongest_sector.sectorId = 'video'
+
+        weakest_sector = copy.deepcopy(self.sector_24h_change[0])
+        weakest_sector.sectorId = 'defi'
+        weakest_sector.title = 'DeFi'
+        weakest_sector.avgPriceChange = -4.8
+
+        backfill_snapshot = Mock()
+        message_sender = self.build_message_sender()
+        message_sender.signal_repository.get_coin_observation_counts_since = Mock(
+            return_value={1: 5, 1027: 5, 5426: 0, 2469: 0}
+        )
+        message_sender.signal_backfill_service.build_snapshots = AsyncMock(
+            return_value=[backfill_snapshot]
+        )
+        message_sender.sentiment_service.get_crypto_fear_greed_index = AsyncMock(
+            return_value=self.sentiment
+        )
+        message_sender.cmc_service.get_sectors_24h_change = AsyncMock(
+            side_effect=[[strongest_sector], [weakest_sector]]
+        )
+        message_sender.cmc_service.get_spotlight = AsyncMock(return_value=self.spotlight)
+        message_sender.cmc_service.get_coin_detail = AsyncMock(return_value=self.coin_detail)
+        message_sender.cmc_service.get_sector_detail = AsyncMock(
+            side_effect=RuntimeError('403 Forbidden')
+        )
+
+        await message_sender.format_message()
+
+        message_sender.signal_backfill_service.build_snapshots.assert_awaited_once()
+        coin_entries = (
+            message_sender.signal_backfill_service.build_snapshots.await_args.kwargs[
+                'coin_entries'
+            ]
+        )
+        coin_ids = {coin_id for _symbol, coin_id in coin_entries}
+        assert 1 not in coin_ids
+        assert 1027 not in coin_ids
+        assert 5426 in coin_ids
+        assert len(coin_entries) > 1
+        message_sender.signal_repository.save_or_merge_snapshot.assert_called_once_with(
+            backfill_snapshot
+        )
+
+    @pytest.mark.asyncio
+    async def test_format_message_continues_when_backfill_count_query_fails(self):
+        strongest_sector = copy.deepcopy(self.sector_24h_change[0])
+        strongest_sector.sectorId = 'video'
+
+        weakest_sector = copy.deepcopy(self.sector_24h_change[0])
+        weakest_sector.sectorId = 'defi'
+        weakest_sector.title = 'DeFi'
+        weakest_sector.avgPriceChange = -4.8
+
+        message_sender = self.build_message_sender()
+        message_sender.signal_repository.get_coin_observation_counts_since = Mock(
+            side_effect=RuntimeError('database is locked')
+        )
+        message_sender.sentiment_service.get_crypto_fear_greed_index = AsyncMock(
+            return_value=self.sentiment
+        )
+        message_sender.cmc_service.get_sectors_24h_change = AsyncMock(
+            side_effect=[[strongest_sector], [weakest_sector]]
+        )
+        message_sender.cmc_service.get_spotlight = AsyncMock(return_value=self.spotlight)
+        message_sender.cmc_service.get_coin_detail = AsyncMock(return_value=self.coin_detail)
+        message_sender.cmc_service.get_sector_detail = AsyncMock(
+            side_effect=RuntimeError('403 Forbidden')
+        )
+
+        messages = await message_sender.format_message()
+
+        assert len(messages) == 1
+        assert '*Crypto market digest*' in messages[0]
+        message_sender.signal_repository.save_snapshot.assert_called_once()
+        message_sender.signal_backfill_service.build_snapshots.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_format_message_adds_threshold_gated_sector_detail(self):

--- a/tests/unit/job/crypto/crypto_job_test.py
+++ b/tests/unit/job/crypto/crypto_job_test.py
@@ -1,16 +1,20 @@
 from src.runtime.runtime_mode import RuntimeMode
 from src.job.crypto.crypto import CryptoNotificationJob
 from src.job.crypto.crypto_digest_message_sender import CryptoDigestMessageSender
+from src.job.crypto.crypto_signal_digest_message_sender import (
+    CryptoSignalDigestMessageSender,
+)
 
 
 class TestCryptoNotificationJob:
-    def test_message_senders_use_single_digest_sender(self) -> None:
+    def test_message_senders_use_public_and_operator_crypto_senders(self) -> None:
         job = CryptoNotificationJob()
 
         senders = job.message_senders
 
-        assert len(senders) == 1
+        assert len(senders) == 2
         assert isinstance(senders[0], CryptoDigestMessageSender)
+        assert isinstance(senders[1], CryptoSignalDigestMessageSender)
 
     def test_should_run_bypasses_schedule_in_test_mode(self) -> None:
         job = CryptoNotificationJob()

--- a/tests/unit/job/crypto/crypto_signal_digest_message_sender_test.py
+++ b/tests/unit/job/crypto/crypto_signal_digest_message_sender_test.py
@@ -13,7 +13,11 @@ from src.service.crypto_signal.models import (
 )
 
 
-def _build_snapshot(run_timestamp_utc: datetime.datetime) -> CryptoSignalSnapshot:
+def _build_snapshot(
+    run_timestamp_utc: datetime.datetime,
+    *,
+    sol_price_usd: float = 184.23,
+) -> CryptoSignalSnapshot:
     return CryptoSignalSnapshot(
         run=CryptoSignalRunRecord(
             run_timestamp_utc=run_timestamp_utc,
@@ -46,7 +50,7 @@ def _build_snapshot(run_timestamp_utc: datetime.datetime) -> CryptoSignalSnapsho
                 coin_id=5426,
                 symbol='SOL',
                 name='Solana',
-                price_usd=184.23,
+                price_usd=sol_price_usd,
                 price_change_24h=11.4,
                 volume_24h=4_820_000_000,
                 volume_change_pct_24h=27.1,
@@ -74,24 +78,36 @@ def _build_snapshot(run_timestamp_utc: datetime.datetime) -> CryptoSignalSnapsho
 
 
 class _FakeRepository:
-    def __init__(self, latest_snapshot: CryptoSignalSnapshot):
+    def __init__(
+        self,
+        latest_snapshot: CryptoSignalSnapshot,
+        history: list[CryptoSignalSnapshot] | None = None,
+    ):
         self.latest_snapshot = latest_snapshot
+        self.history = [latest_snapshot] if history is None else history
 
     def get_latest_snapshot(self):
         return self.latest_snapshot
 
     def get_snapshots_since(self, _start):
-        return [self.latest_snapshot]
+        return self.history
 
 
 @pytest.mark.asyncio
 async def test_format_message_builds_operator_digest(monkeypatch):
+    earlier_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 20, 8, 45, tzinfo=datetime.timezone.utc),
+        sol_price_usd=150.0,
+    )
     latest_snapshot = _build_snapshot(
         datetime.datetime(2026, 4, 21, 8, 45, tzinfo=datetime.timezone.utc)
     )
 
     sender = object.__new__(CryptoSignalDigestMessageSender)
-    sender.signal_repository = _FakeRepository(latest_snapshot)
+    sender.signal_repository = _FakeRepository(
+        latest_snapshot,
+        history=[earlier_snapshot, latest_snapshot],
+    )
     sender.watchlist_entries = [('BTC', 1), ('SOL', 5426)]
     sender.runtime_mode = DEFAULT_RUNTIME_MODE
 
@@ -104,7 +120,8 @@ async def test_format_message_builds_operator_digest(monkeypatch):
 
     assert len(messages) == 1
     assert '*Crypto trend signal*' in messages[0]
-    assert '*Strong momentum*' in messages[0]
+    assert '*Strong 7d momentum*' in messages[0]
+    assert '7d \\+22\\.82%' in messages[0]
     assert '*Watchlist*' in messages[0]
     assert 'Solana' in messages[0]
 

--- a/tests/unit/job/crypto/crypto_signal_digest_message_sender_test.py
+++ b/tests/unit/job/crypto/crypto_signal_digest_message_sender_test.py
@@ -1,0 +1,130 @@
+import datetime
+
+import pytest
+
+from src.job.crypto.crypto_signal_digest_message_sender import (
+    CryptoSignalDigestMessageSender,
+)
+from src.runtime.runtime_mode import DEFAULT_RUNTIME_MODE
+from src.service.crypto_signal.models import (
+    CryptoSignalCoinSnapshot,
+    CryptoSignalRunRecord,
+    CryptoSignalSnapshot,
+)
+
+
+def _build_snapshot(run_timestamp_utc: datetime.datetime) -> CryptoSignalSnapshot:
+    return CryptoSignalSnapshot(
+        run=CryptoSignalRunRecord(
+            run_timestamp_utc=run_timestamp_utc,
+            runtime_mode='prod',
+            source_name='CMC + Alternative.me',
+            snapshot_version=1,
+            sentiment_now_value=63.0,
+            sentiment_now_label='Greed',
+            sentiment_yesterday_value=58.0,
+            sentiment_last_week_value=49.0,
+            sentiment_7d_avg=55.4,
+            sentiment_30d_avg=51.8,
+            strongest_sector_id='ai-big-data',
+            strongest_sector_name='AI & Big Data',
+            strongest_sector_avg_price_change_24h=8.4,
+            strongest_sector_market_change_24h=6.9,
+            strongest_sector_volume_change_24h=21.7,
+            strongest_sector_gainers_num=18,
+            strongest_sector_losers_num=5,
+            weakest_sector_id='gaming',
+            weakest_sector_name='Gaming',
+            weakest_sector_avg_price_change_24h=-6.1,
+            weakest_sector_market_change_24h=-4.8,
+            weakest_sector_volume_change_24h=-12.3,
+            weakest_sector_gainers_num=4,
+            weakest_sector_losers_num=19,
+        ),
+        coins=[
+            CryptoSignalCoinSnapshot(
+                coin_id=5426,
+                symbol='SOL',
+                name='Solana',
+                price_usd=184.23,
+                price_change_24h=11.4,
+                volume_24h=4_820_000_000,
+                volume_change_pct_24h=27.1,
+                is_watchlist=True,
+                context_tags=(
+                    'spotlight_trending',
+                    'spotlight_gainer',
+                    'sector_leader_strongest',
+                    'watchlist',
+                ),
+            ),
+            CryptoSignalCoinSnapshot(
+                coin_id=1,
+                symbol='BTC',
+                name='Bitcoin',
+                price_usd=95_200.0,
+                price_change_24h=2.4,
+                volume_24h=31_000_000_000,
+                volume_change_pct_24h=7.5,
+                is_watchlist=True,
+                context_tags=('watchlist',),
+            ),
+        ],
+    )
+
+
+class _FakeRepository:
+    def __init__(self, latest_snapshot: CryptoSignalSnapshot):
+        self.latest_snapshot = latest_snapshot
+
+    def get_latest_snapshot(self):
+        return self.latest_snapshot
+
+    def get_snapshots_since(self, _start):
+        return [self.latest_snapshot]
+
+
+@pytest.mark.asyncio
+async def test_format_message_builds_operator_digest(monkeypatch):
+    latest_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 21, 8, 45, tzinfo=datetime.timezone.utc)
+    )
+
+    sender = object.__new__(CryptoSignalDigestMessageSender)
+    sender.signal_repository = _FakeRepository(latest_snapshot)
+    sender.watchlist_entries = [('BTC', 1), ('SOL', 5426)]
+    sender.runtime_mode = DEFAULT_RUNTIME_MODE
+
+    monkeypatch.setattr(
+        'src.job.crypto.crypto_signal_digest_message_sender.get_current_datetime',
+        lambda: datetime.datetime(2026, 4, 21, 9, 0, tzinfo=datetime.timezone.utc),
+    )
+
+    messages = await sender.format_message()
+
+    assert len(messages) == 1
+    assert '*Crypto trend signal*' in messages[0]
+    assert '*Strong momentum*' in messages[0]
+    assert '*Watchlist*' in messages[0]
+    assert 'Solana' in messages[0]
+
+
+@pytest.mark.asyncio
+async def test_format_message_skips_stale_snapshot(monkeypatch):
+    latest_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 20, 8, 45, tzinfo=datetime.timezone.utc)
+    )
+
+    sender = object.__new__(CryptoSignalDigestMessageSender)
+    sender.signal_repository = _FakeRepository(latest_snapshot)
+    sender.watchlist_entries = [('BTC', 1), ('SOL', 5426)]
+    sender.runtime_mode = DEFAULT_RUNTIME_MODE
+
+    monkeypatch.setattr(
+        'src.job.crypto.crypto_signal_digest_message_sender.get_current_datetime',
+        lambda: datetime.datetime(2026, 4, 21, 9, 0, tzinfo=datetime.timezone.utc),
+    )
+
+    messages = await sender.format_message()
+
+    assert messages == []

--- a/tests/unit/job/crypto/crypto_signal_formatter_test.py
+++ b/tests/unit/job/crypto/crypto_signal_formatter_test.py
@@ -1,0 +1,91 @@
+import datetime
+
+from src.job.crypto.crypto_signal_formatter import build_crypto_signal_message
+from src.service.crypto_signal.models import (
+    CryptoSignalCandidate,
+    CryptoSignalDigestView,
+    CryptoSignalRunRecord,
+    CryptoSignalSnapshot,
+)
+
+
+def test_build_crypto_signal_message_uses_reason_tags_not_raw_context_tags():
+    snapshot = CryptoSignalSnapshot(
+        run=CryptoSignalRunRecord(
+            run_timestamp_utc=datetime.datetime(
+                2026,
+                4,
+                22,
+                8,
+                45,
+                tzinfo=datetime.timezone.utc,
+            ),
+            runtime_mode='prod',
+            source_name='CMC + Alternative.me',
+            snapshot_version=1,
+            sentiment_now_value=63.0,
+            sentiment_now_label='Greed',
+            sentiment_yesterday_value=58.0,
+            sentiment_last_week_value=49.0,
+            sentiment_7d_avg=55.4,
+            sentiment_30d_avg=51.8,
+            strongest_sector_id='ai-big-data',
+            strongest_sector_name='AI & Big Data',
+            strongest_sector_avg_price_change_24h=8.4,
+            strongest_sector_market_change_24h=6.9,
+            strongest_sector_volume_change_24h=21.7,
+            strongest_sector_gainers_num=18,
+            strongest_sector_losers_num=5,
+            weakest_sector_id='gaming',
+            weakest_sector_name='Gaming',
+            weakest_sector_avg_price_change_24h=-6.1,
+            weakest_sector_market_change_24h=-4.8,
+            weakest_sector_volume_change_24h=-12.3,
+            weakest_sector_gainers_num=4,
+            weakest_sector_losers_num=19,
+        ),
+        coins=[],
+    )
+    candidate = CryptoSignalCandidate(
+        coin_id=5426,
+        symbol='SOL',
+        name='Solana',
+        latest_price_usd=184.23,
+        latest_price_change_24h=11.4,
+        latest_volume_change_pct_24h=27.1,
+        latest_context_tags=(
+            'spotlight_trending',
+            'sector_leader_strongest',
+        ),
+        score=9,
+        price_persistence_score=4,
+        volume_confirmation_score=2,
+        attention_persistence_score=2,
+        breadth_alignment_score=1,
+        observation_count=4,
+        reason_tags=(
+            'price-up-persistent',
+            'vol-confirm',
+            'spotlight-repeat',
+            'breadth-align',
+            'risk-on',
+        ),
+        flags=('risk-on', 'watchlist'),
+        is_watchlist=True,
+    )
+    view = CryptoSignalDigestView(
+        latest_snapshot=snapshot,
+        window_label='7d',
+        market_regime_label='Risk-on bias',
+        market_regime_reason='sentiment 63 with strongest sector +8.4%',
+        strong_candidates=[candidate],
+        weak_candidates=[],
+        watchlist_candidates=[candidate],
+    )
+
+    message = build_crypto_signal_message(view)
+
+    assert 'price\\-up\\-persistent' in message
+    assert 'vol\\-confirm' in message
+    assert 'spotlight\\_trending' not in message
+    assert 'sector\\_leader\\_strongest' not in message

--- a/tests/unit/job/crypto/crypto_signal_formatter_test.py
+++ b/tests/unit/job/crypto/crypto_signal_formatter_test.py
@@ -53,6 +53,7 @@ def test_build_crypto_signal_message_uses_reason_tags_not_raw_context_tags():
         latest_price_usd=184.23,
         latest_volume_24h=4_820_000_000,
         latest_price_change_24h=11.4,
+        window_price_change_pct=24.7,
         latest_volume_change_pct_24h=27.1,
         latest_context_tags=(
             'spotlight_trending',
@@ -87,6 +88,9 @@ def test_build_crypto_signal_message_uses_reason_tags_not_raw_context_tags():
     message = build_crypto_signal_message(view)
 
     assert 'price\\-up\\-persistent' in message
+    assert '*Strong 7d momentum*' in message
+    assert '7d \\+24\\.70%' in message
+    assert '24h \\+11\\.40%' in message
     assert 'vol\\-confirm' in message
     assert 'spotlight\\_trending' not in message
     assert 'sector\\_leader\\_strongest' not in message

--- a/tests/unit/job/crypto/crypto_signal_formatter_test.py
+++ b/tests/unit/job/crypto/crypto_signal_formatter_test.py
@@ -51,6 +51,7 @@ def test_build_crypto_signal_message_uses_reason_tags_not_raw_context_tags():
         symbol='SOL',
         name='Solana',
         latest_price_usd=184.23,
+        latest_volume_24h=4_820_000_000,
         latest_price_change_24h=11.4,
         latest_volume_change_pct_24h=27.1,
         latest_context_tags=(

--- a/tests/unit/job/crypto/crypto_signal_report_test.py
+++ b/tests/unit/job/crypto/crypto_signal_report_test.py
@@ -1,0 +1,109 @@
+import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.job.crypto import crypto_signal_report
+from src.service.crypto_signal.models import (
+    CryptoSignalCoinSnapshot,
+    CryptoSignalRunRecord,
+    CryptoSignalSnapshot,
+)
+
+
+def _build_snapshot() -> CryptoSignalSnapshot:
+    return CryptoSignalSnapshot(
+        run=CryptoSignalRunRecord(
+            run_timestamp_utc=datetime.datetime(2026, 4, 22, 8, 45, tzinfo=datetime.timezone.utc),
+            runtime_mode='prod',
+            source_name='CMC + Alternative.me',
+            snapshot_version=1,
+            sentiment_now_value=63.0,
+            sentiment_now_label='Greed',
+            sentiment_yesterday_value=58.0,
+            sentiment_last_week_value=49.0,
+            sentiment_7d_avg=55.4,
+            sentiment_30d_avg=51.8,
+            strongest_sector_id='ai-big-data',
+            strongest_sector_name='AI & Big Data',
+            strongest_sector_avg_price_change_24h=8.4,
+            strongest_sector_market_change_24h=6.9,
+            strongest_sector_volume_change_24h=21.7,
+            strongest_sector_gainers_num=18,
+            strongest_sector_losers_num=5,
+            weakest_sector_id='gaming',
+            weakest_sector_name='Gaming',
+            weakest_sector_avg_price_change_24h=-6.1,
+            weakest_sector_market_change_24h=-4.8,
+            weakest_sector_volume_change_24h=-12.3,
+            weakest_sector_gainers_num=4,
+            weakest_sector_losers_num=19,
+        ),
+        coins=[
+            CryptoSignalCoinSnapshot(
+                coin_id=1,
+                symbol='BTC',
+                name='Bitcoin',
+                price_usd=95_200.0,
+                price_change_24h=2.4,
+                volume_24h=31_000_000_000,
+                volume_change_pct_24h=7.5,
+                is_watchlist=True,
+                context_tags=('watchlist',),
+            )
+        ],
+    )
+
+
+class _FakeRepository:
+    def __init__(self, latest_snapshot: CryptoSignalSnapshot):
+        self.latest_snapshot = latest_snapshot
+
+    def get_latest_snapshot(self):
+        return self.latest_snapshot
+
+    def get_snapshots_since(self, _start):
+        return [self.latest_snapshot]
+
+
+@pytest.mark.asyncio
+async def test_main_prints_report_to_stdout_when_send_telegram_disabled(
+    monkeypatch,
+    capsys,
+):
+    snapshot = _build_snapshot()
+    fake_repository = _FakeRepository(snapshot)
+    send_crypto_signal_message = AsyncMock()
+
+    monkeypatch.setattr(
+        crypto_signal_report.argparse.ArgumentParser,
+        'parse_args',
+        lambda _self: SimpleNamespace(window='7d', limit=3, send_telegram=0, test_mode=0),
+    )
+    monkeypatch.setattr(
+        crypto_signal_report,
+        'CryptoSignalRepository',
+        lambda: fake_repository,
+    )
+    monkeypatch.setattr(
+        crypto_signal_report,
+        'build_crypto_signal_message',
+        lambda _view: '*Crypto trend signal*',
+    )
+    monkeypatch.setattr(
+        crypto_signal_report.config,
+        'get_crypto_signal_watchlist',
+        lambda: [('BTC', 1)],
+    )
+    monkeypatch.setattr(
+        crypto_signal_report,
+        'send_crypto_signal_message',
+        send_crypto_signal_message,
+    )
+
+    await crypto_signal_report.main()
+
+    captured = capsys.readouterr()
+    assert captured.out == '*Crypto trend signal*\n'
+    send_crypto_signal_message.assert_not_awaited()

--- a/tests/unit/job/crypto/crypto_signal_report_test.py
+++ b/tests/unit/job/crypto/crypto_signal_report_test.py
@@ -84,7 +84,7 @@ async def test_main_prints_report_to_stdout_when_send_telegram_disabled(
     monkeypatch.setattr(
         crypto_signal_report,
         'CryptoSignalRepository',
-        lambda: fake_repository,
+        lambda runtime_mode=None: fake_repository,
     )
     monkeypatch.setattr(
         crypto_signal_report,

--- a/tests/unit/notification_destination/telegram_notification_test.py
+++ b/tests/unit/notification_destination/telegram_notification_test.py
@@ -484,3 +484,44 @@ async def test_send_crypto_signal_message_rejects_public_crypto_channel(
             chat_id='crypto-channel',
             runtime_mode=RuntimeMode(),
         )
+
+
+@pytest.mark.asyncio
+async def test_send_crypto_signal_message_keeps_admin_routing_in_test_mode(
+    monkeypatch,
+):
+    admin_client = AsyncMock()
+    admin_client.send_message = AsyncMock(
+        return_value=_build_message_response(message_id=78)
+    )
+    dev_client = AsyncMock()
+
+    monkeypatch.setattr(telegram_notification, 'crypto_admin_bot', admin_client)
+    monkeypatch.setattr(telegram_notification, 'crypto_dev_bot', dev_client)
+    monkeypatch.setattr(
+        telegram_notification.config,
+        'get_disable_telegram',
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        telegram_notification.config,
+        'get_crypto_signal_recipient_id',
+        lambda: 'crypto-admin-chat',
+    )
+    monkeypatch.setattr(
+        telegram_notification.config,
+        'get_telegram_crypto_channel_id',
+        lambda: 'crypto-channel',
+    )
+
+    await telegram_notification.send_crypto_signal_message(
+        message='signal body',
+        runtime_mode=RuntimeMode.from_test_mode(True),
+    )
+
+    admin_client.send_message.assert_awaited_once_with(
+        chat_id='crypto-admin-chat',
+        text='signal body',
+        parse_mode='MarkdownV2',
+    )
+    dev_client.send_message.assert_not_awaited()

--- a/tests/unit/notification_destination/telegram_notification_test.py
+++ b/tests/unit/notification_destination/telegram_notification_test.py
@@ -397,3 +397,90 @@ async def test_send_message_to_channel_defaults_to_prod_routing_without_runtime_
 
     prod_client.send_message.assert_awaited_once()
     dev_client.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_crypto_signal_message_uses_admin_bot_for_custom_operator_chat(
+    monkeypatch,
+):
+    admin_client = AsyncMock()
+    admin_client.send_message = AsyncMock(
+        return_value=_build_message_response(message_id=77)
+    )
+
+    monkeypatch.setattr(telegram_notification, 'crypto_admin_bot', admin_client)
+    monkeypatch.setattr(telegram_notification, 'crypto_dev_bot', AsyncMock())
+    monkeypatch.setattr(telegram_notification, 'crypto_bot', AsyncMock())
+    monkeypatch.setattr(
+        telegram_notification.config,
+        'get_disable_telegram',
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        telegram_notification.config,
+        'get_simulate_tradingview_traffic',
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        telegram_notification.config,
+        'get_crypto_signal_recipient_id',
+        lambda: 'operator-chat',
+    )
+    monkeypatch.setattr(
+        telegram_notification.config,
+        'get_telegram_crypto_channel_id',
+        lambda: 'crypto-channel',
+    )
+    monkeypatch.setattr(
+        telegram_notification.config,
+        'get_telegram_crypto_dev_id',
+        lambda: 'crypto-dev-chat',
+    )
+
+    await telegram_notification.send_crypto_signal_message(
+        message='signal body',
+        chat_id='operator-chat',
+        runtime_mode=RuntimeMode(),
+    )
+
+    admin_client.send_message.assert_awaited_once_with(
+        chat_id='operator-chat',
+        text='signal body',
+        parse_mode='MarkdownV2',
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_crypto_signal_message_rejects_public_crypto_channel(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        telegram_notification.config,
+        'get_disable_telegram',
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        telegram_notification.config,
+        'get_simulate_tradingview_traffic',
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        telegram_notification.config,
+        'get_telegram_crypto_channel_id',
+        lambda: 'crypto-channel',
+    )
+    monkeypatch.setattr(
+        telegram_notification.config,
+        'get_telegram_crypto_dev_id',
+        lambda: 'crypto-dev-chat',
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match='public crypto channel is disabled in phase 1',
+    ):
+        await telegram_notification.send_crypto_signal_message(
+            message='signal body',
+            chat_id='crypto-channel',
+            runtime_mode=RuntimeMode(),
+        )

--- a/tests/unit/router/tradingview_test.py
+++ b/tests/unit/router/tradingview_test.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import json
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -76,6 +77,62 @@ class TestTradingViewRouter:
         emitted.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_tradingview_daily_stocks_data_logs_metadata_only(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        fixed_now = datetime.datetime(2026, 3, 26, 9, 0, tzinfo=datetime.timezone.utc)
+        tradingview_service = SimpleNamespace(
+            get_redis_key_for_stocks=Mock(return_value='tradingview-stocks'),
+            save_tradingview_data=AsyncMock(return_value=[1, 0]),
+        )
+
+        monkeypatch.setattr(tradingview, 'get_current_date', lambda: fixed_now)
+        monkeypatch.setattr(
+            tradingview.Dependencies,
+            'get_tradingview_service',
+            lambda: tradingview_service,
+        )
+        monkeypatch.setattr(tradingview.async_ee, 'emit', Mock())
+        monkeypatch.setattr(
+            tradingview.config,
+            'get_tradingview_webhook_secret',
+            lambda: 'secret',
+        )
+        monkeypatch.setattr(
+            tradingview.config,
+            'get_simulate_tradingview_traffic',
+            lambda: True,
+        )
+        monkeypatch.setattr(tradingview.config, 'get_trading_view_ips', lambda: [])
+        monkeypatch.setattr(tradingview.config, 'get_whitelist_ips', lambda: [])
+        monkeypatch.setattr(
+            tradingview.config,
+            'get_trading_view_days_to_store',
+            lambda: 30,
+        )
+        monkeypatch.setattr(
+            tradingview.config,
+            'get_telegram_stocks_admin_id',
+            lambda: 'admin-chat',
+        )
+        caplog.set_level(logging.INFO, logger='Trading view')
+
+        request = DummyRequest(
+            r'{\"type\": \"stocks\", \"secret\": \"secret\", \"test_mode\": \"false\", \"unix_ms\": 1, \"data\": [{\"symbol\": \"SPY\", \"timeframe\": \"1D\", \"close_prices\": [1, 2], \"nested\": {\"secret\": \"nested-secret\"}}], \"unexpected\": \"do-not-log\"}'
+        )
+
+        response = await tradingview.tradingview_daily_stocks_data(request)
+
+        assert response == {'data': {'num_added': 1, 'num_removed': 0}}
+        assert 'TradingView webhook payload metadata' in caplog.text
+        assert 'data_count=1' in caplog.text
+        assert 'close_prices' not in caplog.text
+        assert 'nested-secret' not in caplog.text
+        assert 'do-not-log' not in caplog.text
+
+    @pytest.mark.asyncio
     async def test_tradingview_daily_stocks_data_uses_canonical_key_in_test_mode(self, monkeypatch):
         fixed_now = datetime.datetime(2026, 3, 26, 9, 0, tzinfo=datetime.timezone.utc)
         tradingview_service = SimpleNamespace(
@@ -126,6 +183,74 @@ class TestTradingViewRouter:
         assert response == {'data': None}
         tradingview_service.save_tradingview_data.assert_not_awaited()
         emitted.assert_called_once()
+        assert 'Data item count' in emitted.call_args.kwargs['message']
+
+    @pytest.mark.asyncio
+    async def test_tradingview_daily_stocks_data_alerts_bounded_context_without_raw_secret_or_headers(
+        self,
+        monkeypatch,
+    ):
+        emitted = Mock()
+
+        monkeypatch.setattr(tradingview.async_ee, 'emit', emitted)
+        monkeypatch.setattr(tradingview.config, 'get_tradingview_webhook_secret', lambda: 'expected-secret')
+        monkeypatch.setattr(tradingview.config, 'get_telegram_stocks_admin_id', lambda: 'admin-chat')
+
+        request = DummyRequest(
+            r'{\"type\": \"stocks\", \"secret\": \"wrong-secret\", \"test_mode\": \"false\", \"unix_ms\": 1774468860948, \"data\": [{\"symbol\": \"SPY\", \"timeframe\": \"1D\", \"close_prices\": [1, 2], \"ema20s\": [1, 2], \"volumes\": [10, 20]}], \"unexpected\": \"do-not-alert\"}',
+            headers={'X-Api-Auth': 'private-token'},
+        )
+
+        response = await tradingview.tradingview_daily_stocks_data(request)
+
+        assert response == {'data': 'OK'}
+        message = emitted.call_args.kwargs['message']
+        assert 'Incorrect tradingview webhook secret' in message
+        assert 'Payload type' in message
+        assert 'Data item count' in message
+        assert 'SPY 1D' in message
+        assert 'Payload preview' in message
+        assert 'close\\_prices' in message
+        assert 'private-token' not in message
+        assert 'wrong-secret' not in message
+        assert 'do-not-alert' not in message
+        assert 'Headers' not in message
+        assert 'Body' not in message
+
+    @pytest.mark.asyncio
+    async def test_tradingview_daily_stocks_data_alerts_bounded_context_for_bad_ip(
+        self,
+        monkeypatch,
+    ):
+        emitted = Mock()
+
+        monkeypatch.setattr(tradingview.async_ee, 'emit', emitted)
+        monkeypatch.setattr(tradingview.config, 'get_tradingview_webhook_secret', lambda: 'expected-secret')
+        monkeypatch.setattr(tradingview.config, 'get_simulate_tradingview_traffic', lambda: False)
+        monkeypatch.setattr(tradingview.config, 'get_trading_view_ips', lambda: ['192.0.2.10'])
+        monkeypatch.setattr(tradingview.config, 'get_whitelist_ips', lambda: [])
+        monkeypatch.setattr(tradingview.config, 'get_telegram_stocks_admin_id', lambda: 'admin-chat')
+
+        request = DummyRequest(
+            r'{\"type\": \"stocks\", \"secret\": \"expected-secret\", \"test_mode\": \"false\", \"unix_ms\": 1774468860948, \"data\": [{\"symbol\": \"QQQ\", \"timeframe\": \"1D\", \"close_prices\": [1, 2], \"ema20s\": [1, 2], \"volumes\": [10, 20]}]}',
+            host='203.0.113.10',
+            headers={'X-Api-Auth': 'private-token'},
+        )
+
+        response = await tradingview.tradingview_daily_stocks_data(request)
+
+        assert response == {'data': 'OK'}
+        message = emitted.call_args.kwargs['message']
+        assert 'not from a configured TradingView source' in message
+        assert 'Payload type' in message
+        assert 'Data item count' in message
+        assert 'QQQ 1D' in message
+        assert 'Payload preview' in message
+        assert 'close\\_prices' in message
+        assert 'private-token' not in message
+        assert 'expected-secret' not in message
+        assert 'Headers' not in message
+        assert 'Body' not in message
 
     @pytest.mark.asyncio
     async def test_tradingview_daily_stocks_data_keeps_test_mode_request_local_under_concurrency(
@@ -210,3 +335,66 @@ class TestTradingViewRouter:
         expected_score = int(fallback.timestamp()) if expected is None else expected
 
         assert result == expected_score
+
+    def test_format_tradingview_alert_context_includes_ticker_preview_only(self):
+        context = tradingview.format_tradingview_alert_context(
+            {
+                'type': 'stocks',
+                'test_mode': 'false',
+                'unix_ms': 1774468860948,
+                'unexpected': 'do-not-alert',
+                'data': [
+                    {
+                        'symbol': 'SPY',
+                        'timeframe': '1D',
+                        'close_prices': [100, 101],
+                        'ema20s': [99, 100],
+                        'volumes': [1, 2],
+                    },
+                    {
+                        'symbol': 'QQQ',
+                        'timeframe': '1D',
+                        'close_prices': [200, 201],
+                    },
+                ],
+            }
+        )
+
+        assert 'stocks' in context
+        assert '1774468860948' in context
+        assert 'Data item count' in context
+        assert 'SPY 1D, QQQ 1D' in context
+        assert 'Payload preview' in context
+        assert 'close\\_prices' in context
+        assert 'ema20s' in context
+        assert 'volumes' in context
+        assert 'do-not-alert' not in context
+
+    def test_format_tradingview_alert_context_caps_oversized_sample_values(self):
+        long_symbol = 'S' * 1000
+        long_timeframe = 'T' * 1000
+        long_price = '9' * 1000
+
+        context = tradingview.format_tradingview_alert_context(
+            {
+                'type': 'stocks',
+                'test_mode': 'false',
+                'unix_ms': 1774468860948,
+                'data': [
+                    {
+                        'symbol': long_symbol,
+                        'timeframe': long_timeframe,
+                        'close_prices': [long_price] * 100,
+                        'ema20s': [long_price] * 100,
+                        'volumes': [long_price] * 100,
+                    },
+                ],
+            }
+        )
+
+        assert long_symbol not in context
+        assert long_timeframe not in context
+        assert long_price not in context
+        assert 'S' * 29 in context
+        assert 'T' * 29 in context
+        assert len(context) < 1200

--- a/tests/unit/server_test.py
+++ b/tests/unit/server_test.py
@@ -1,0 +1,118 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from starlette.datastructures import URL
+
+from src import server
+
+
+class DummyRequest:
+    def __init__(self, method: str, url: str, headers=None):
+        self.method = method
+        self.url = URL(url)
+        self.headers = headers or {}
+        self.client = SimpleNamespace(host='203.0.113.10')
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('method', 'path'),
+    [
+        ('GET', '/healthz'),
+        ('POST', '/tradingview/daily-stocks'),
+    ],
+)
+async def test_auth_check_allows_exact_public_routes_without_token(
+    monkeypatch,
+    method,
+    path,
+):
+    expected_response = SimpleNamespace(status_code=200)
+    call_next = AsyncMock(return_value=expected_response)
+    request = DummyRequest(method, f'https://example.com{path}')
+
+    monkeypatch.setattr(server.config, 'get_env', lambda: 'prod')
+
+    response = await server.auth_check(request, call_next)
+
+    assert response is expected_response
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_auth_check_rejects_protected_route_when_exclusion_env_is_blank(
+    monkeypatch,
+):
+    call_next = AsyncMock()
+    request = DummyRequest('GET', 'https://example.com/cryptoquant/price-ohlcv')
+
+    monkeypatch.setattr(server.config, 'get_env', lambda: 'prod')
+    monkeypatch.setattr(server.config, 'get_api_auth_token', lambda: 'expected-token')
+
+    response = await server.auth_check(request, call_next)
+
+    assert response.status_code == 500
+    call_next.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auth_check_does_not_use_localhost_host_bypass_in_prod(monkeypatch):
+    call_next = AsyncMock()
+    request = DummyRequest('GET', 'https://localhost/cryptoquant/price-ohlcv')
+
+    monkeypatch.setattr(server.config, 'get_env', lambda: 'prod')
+    monkeypatch.setattr(server.config, 'get_api_auth_token', lambda: 'expected-token')
+
+    response = await server.auth_check(request, call_next)
+
+    assert response.status_code == 500
+    call_next.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auth_check_rejects_substring_match_on_public_route(monkeypatch):
+    call_next = AsyncMock()
+    request = DummyRequest('GET', 'https://example.com/internal/healthz/details')
+
+    monkeypatch.setattr(server.config, 'get_env', lambda: 'prod')
+    monkeypatch.setattr(server.config, 'get_api_auth_token', lambda: 'expected-token')
+
+    response = await server.auth_check(request, call_next)
+
+    assert response.status_code == 500
+    call_next.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auth_check_allows_private_route_with_valid_token(monkeypatch):
+    expected_response = SimpleNamespace(status_code=200)
+    call_next = AsyncMock(return_value=expected_response)
+    request = DummyRequest(
+        'GET',
+        'https://example.com/cryptoquant/price-ohlcv',
+        headers={'X-Api-Auth': 'expected-token'},
+    )
+
+    monkeypatch.setattr(server.config, 'get_env', lambda: 'prod')
+    monkeypatch.setattr(server.config, 'get_api_auth_token', lambda: 'expected-token')
+
+    response = await server.auth_check(request, call_next)
+
+    assert response is expected_response
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('path', ['/docs', '/redoc', '/openapi.json'])
+async def test_auth_check_protects_fastapi_docs_routes_in_prod(monkeypatch, path):
+    call_next = AsyncMock()
+    request = DummyRequest('GET', f'https://example.com{path}')
+
+    monkeypatch.setattr(server.config, 'get_env', lambda: 'prod')
+    monkeypatch.setattr(server.config, 'get_api_auth_token', lambda: 'expected-token')
+
+    response = await server.auth_check(request, call_next)
+
+    assert response.status_code == 500
+    call_next.assert_not_called()

--- a/tests/unit/service/crypto_signal/backfill_test.py
+++ b/tests/unit/service/crypto_signal/backfill_test.py
@@ -1,0 +1,204 @@
+import datetime
+
+import pytest
+from market_data_library.types import cmc_type
+
+from src.service.crypto_signal.backfill import (
+    BACKFILL_RUNTIME_MODE,
+    BACKFILL_SOURCE_NAME,
+    CryptoSignalBackfillService,
+)
+
+
+def _build_quote(
+    timestamp: str,
+    *,
+    close: float,
+    volume: float,
+) -> cmc_type.OHLCVHistoricalQuote:
+    return cmc_type.OHLCVHistoricalQuote(
+        timeOpen=timestamp,
+        timeClose=timestamp,
+        timeHigh=timestamp,
+        timeLow=timestamp,
+        quote=cmc_type.OHLCVHistoricalInnerQuote(
+            open=close,
+            high=close,
+            low=close,
+            close=close,
+            volume=volume,
+            marketCap=0,
+            timestamp=timestamp,
+        ),
+    )
+
+
+def _build_history(
+    *,
+    coin_id: int,
+    name: str,
+    symbol: str,
+    quotes: list[cmc_type.OHLCVHistoricalQuote],
+) -> cmc_type.OHLCVHistorical:
+    return cmc_type.OHLCVHistorical(
+        id=coin_id,
+        name=name,
+        symbol=symbol,
+        timeEnd=quotes[-1].quote.timestamp if quotes else '',
+        quotes=quotes,
+    )
+
+
+class _FakeCryptoStatsService:
+    def __init__(self, responses: dict[int, object]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[int, str]] = []
+
+    async def get_ohlcv_historical(
+        self,
+        id: int,
+        interval: str = '24h',
+    ) -> cmc_type.OHLCVHistorical:
+        self.calls.append((id, interval))
+        response = self.responses[id]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+@pytest.mark.asyncio
+async def test_build_snapshots_groups_daily_history_filters_window_and_marks_watchlist():
+    btc_history = _build_history(
+        coin_id=1,
+        name='Bitcoin',
+        symbol='BTC',
+        quotes=[
+            _build_quote(
+                '2026-03-20T00:00:00.000Z',
+                close=80_000.0,
+                volume=10_000_000.0,
+            ),
+            _build_quote(
+                '2026-03-25T00:00:00.000Z',
+                close=100_000.0,
+                volume=15_000_000.0,
+            ),
+            _build_quote(
+                '2026-03-26T00:00:00.000Z',
+                close=110_000.0,
+                volume=18_000_000.0,
+            ),
+            _build_quote(
+                '2026-04-24T00:00:00.000Z',
+                close=130_000.0,
+                volume=21_000_000.0,
+            ),
+        ],
+    )
+    eth_history = _build_history(
+        coin_id=1027,
+        name='Ethereum',
+        symbol='ETH',
+        quotes=[
+            _build_quote(
+                '2026-03-25T00:00:00.000Z',
+                close=2_000.0,
+                volume=5_000_000.0,
+            ),
+            _build_quote(
+                '2026-03-26T00:00:00.000Z',
+                close=2_200.0,
+                volume=6_000_000.0,
+            ),
+        ],
+    )
+    service = CryptoSignalBackfillService(
+        cmc_service=_FakeCryptoStatsService(
+            responses={
+                1: btc_history,
+                1027: eth_history,
+            }
+        )
+    )
+
+    snapshots = await service.build_snapshots(
+        coin_entries=[('BTC', 1), ('ETH', 1027), ('BTC', 1)],
+        watchlist_coin_ids={1},
+        current_timestamp_utc=datetime.datetime(
+            2026,
+            4,
+            23,
+            8,
+            45,
+            tzinfo=datetime.timezone.utc,
+        ),
+        days=30,
+    )
+
+    assert [snapshot.run.run_timestamp_utc for snapshot in snapshots] == [
+        datetime.datetime(2026, 3, 25, 0, 0, tzinfo=datetime.timezone.utc),
+        datetime.datetime(2026, 3, 26, 0, 0, tzinfo=datetime.timezone.utc),
+    ]
+    first_snapshot = snapshots[0]
+    assert first_snapshot.run.runtime_mode == BACKFILL_RUNTIME_MODE
+    assert first_snapshot.run.source_name == BACKFILL_SOURCE_NAME
+    assert [coin.symbol for coin in first_snapshot.coins] == ['BTC', 'ETH']
+    btc_coin = first_snapshot.coins[0]
+    eth_coin = first_snapshot.coins[1]
+    assert btc_coin.is_watchlist is True
+    assert btc_coin.context_tags == ('watchlist',)
+    assert round(btc_coin.price_change_24h or 0, 2) == 25.0
+    assert round(btc_coin.volume_change_pct_24h or 0, 2) == 50.0
+    assert eth_coin.is_watchlist is False
+    assert eth_coin.context_tags == ()
+    assert eth_coin.price_change_24h is None
+    assert eth_coin.volume_change_pct_24h is None
+
+    second_snapshot = snapshots[1]
+    second_btc_coin = second_snapshot.coins[0]
+    second_eth_coin = second_snapshot.coins[1]
+    assert round(second_btc_coin.price_change_24h or 0, 2) == 10.0
+    assert round(second_btc_coin.volume_change_pct_24h or 0, 2) == 20.0
+    assert round(second_eth_coin.price_change_24h or 0, 2) == 10.0
+    assert round(second_eth_coin.volume_change_pct_24h or 0, 2) == 20.0
+
+
+@pytest.mark.asyncio
+async def test_build_snapshots_skips_failed_coin_history_and_returns_empty_for_empty_entries():
+    fake_service = _FakeCryptoStatsService(
+        responses={
+            1: RuntimeError('cmc unavailable'),
+        }
+    )
+    service = CryptoSignalBackfillService(cmc_service=fake_service)
+
+    empty_result = await service.build_snapshots(
+        coin_entries=[],
+        watchlist_coin_ids=set(),
+        current_timestamp_utc=datetime.datetime(
+            2026,
+            4,
+            23,
+            8,
+            45,
+            tzinfo=datetime.timezone.utc,
+        ),
+        days=30,
+    )
+    skipped_result = await service.build_snapshots(
+        coin_entries=[('BTC', 1)],
+        watchlist_coin_ids={1},
+        current_timestamp_utc=datetime.datetime(
+            2026,
+            4,
+            23,
+            8,
+            45,
+            tzinfo=datetime.timezone.utc,
+        ),
+        days=30,
+    )
+
+    assert empty_result == []
+    assert skipped_result == []
+    assert fake_service.calls == [(1, '24h')]

--- a/tests/unit/service/crypto_signal/repository_test.py
+++ b/tests/unit/service/crypto_signal/repository_test.py
@@ -200,6 +200,29 @@ def test_get_latest_snapshot_returns_none_when_db_is_missing(tmp_path):
     assert not (tmp_path / 'missing_crypto_signal.sqlite3').exists()
 
 
+def test_get_coin_observation_counts_since_does_not_create_missing_db(tmp_path):
+    db_path = tmp_path / 'missing_crypto_signal.sqlite3'
+    repository = CryptoSignalRepository(db_path=str(db_path))
+
+    counts = repository.get_coin_observation_counts_since(
+        coin_ids=[1, 5426],
+        start_timestamp_utc=datetime.datetime(
+            2026,
+            4,
+            20,
+            0,
+            0,
+            tzinfo=datetime.timezone.utc,
+        ),
+    )
+
+    assert counts == {
+        1: 0,
+        5426: 0,
+    }
+    assert not db_path.exists()
+
+
 def test_save_or_merge_snapshot_reuses_run_timestamp_and_upserts_coin_rows(tmp_path):
     repository = CryptoSignalRepository(
         db_path=str(tmp_path / 'crypto_signal.sqlite3')

--- a/tests/unit/service/crypto_signal/repository_test.py
+++ b/tests/unit/service/crypto_signal/repository_test.py
@@ -7,6 +7,7 @@ from src.service.crypto_signal.models import (
     CryptoSignalSnapshot,
 )
 from src.service.crypto_signal.repository import CryptoSignalRepository
+from src.runtime.runtime_mode import RuntimeMode
 
 
 def test_save_snapshot_and_load_latest_snapshot(tmp_path):
@@ -106,3 +107,282 @@ def test_init_schema_sets_schema_version_metadata(tmp_path):
     connection.close()
 
     assert row == ('1',)
+
+
+def test_repository_uses_runtime_specific_default_db_path(monkeypatch):
+    monkeypatch.delenv('CRYPTO_SIGNAL_DB_PATH', raising=False)
+    monkeypatch.delenv('CRYPTO_SIGNAL_TEST_DB_PATH', raising=False)
+
+    repository = CryptoSignalRepository(
+        runtime_mode=RuntimeMode.from_test_mode(True)
+    )
+
+    assert repository.db_path == 'var/crypto_signal/crypto_signal.test.sqlite3'
+
+
+def test_get_latest_snapshot_reads_existing_db_through_readonly_connection(tmp_path):
+    db_path = tmp_path / 'crypto_signal.sqlite3'
+    writable_repository = CryptoSignalRepository(db_path=str(db_path))
+    snapshot = CryptoSignalSnapshot(
+        run=CryptoSignalRunRecord(
+            run_timestamp_utc=datetime.datetime(
+                2026,
+                4,
+                21,
+                8,
+                45,
+                tzinfo=datetime.timezone.utc,
+            ),
+            runtime_mode='prod',
+            source_name='CMC + Alternative.me',
+            snapshot_version=1,
+            sentiment_now_value=63.0,
+            sentiment_now_label='Greed',
+            sentiment_yesterday_value=58.0,
+            sentiment_last_week_value=49.0,
+            sentiment_7d_avg=55.4,
+            sentiment_30d_avg=51.8,
+            strongest_sector_id='ai-big-data',
+            strongest_sector_name='AI & Big Data',
+            strongest_sector_avg_price_change_24h=8.4,
+            strongest_sector_market_change_24h=6.9,
+            strongest_sector_volume_change_24h=21.7,
+            strongest_sector_gainers_num=18,
+            strongest_sector_losers_num=5,
+            weakest_sector_id='gaming',
+            weakest_sector_name='Gaming',
+            weakest_sector_avg_price_change_24h=-6.1,
+            weakest_sector_market_change_24h=-4.8,
+            weakest_sector_volume_change_24h=-12.3,
+            weakest_sector_gainers_num=4,
+            weakest_sector_losers_num=19,
+        ),
+        coins=[
+            CryptoSignalCoinSnapshot(
+                coin_id=1,
+                symbol='BTC',
+                name='Bitcoin',
+                price_usd=95_200.0,
+                price_change_24h=2.4,
+                volume_24h=31_000_000_000,
+                volume_change_pct_24h=7.5,
+                is_watchlist=False,
+                context_tags=(),
+            )
+        ],
+    )
+    writable_repository.save_snapshot(snapshot)
+
+    readonly_repository = CryptoSignalRepository(db_path=str(db_path))
+
+    def _readonly_connect():
+        connection = sqlite3.connect(
+            f'file:{db_path}?mode=ro',
+            uri=True,
+        )
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    readonly_repository._connect = _readonly_connect
+    latest_snapshot = readonly_repository.get_latest_snapshot()
+
+    assert latest_snapshot is not None
+    assert latest_snapshot.run.run_timestamp_utc == snapshot.run.run_timestamp_utc
+    assert [coin.symbol for coin in latest_snapshot.coins] == ['BTC']
+
+
+def test_get_latest_snapshot_returns_none_when_db_is_missing(tmp_path):
+    repository = CryptoSignalRepository(
+        db_path=str(tmp_path / 'missing_crypto_signal.sqlite3')
+    )
+
+    assert repository.get_latest_snapshot() is None
+    assert not (tmp_path / 'missing_crypto_signal.sqlite3').exists()
+
+
+def test_save_or_merge_snapshot_reuses_run_timestamp_and_upserts_coin_rows(tmp_path):
+    repository = CryptoSignalRepository(
+        db_path=str(tmp_path / 'crypto_signal.sqlite3')
+    )
+    run_timestamp_utc = datetime.datetime(
+        2026,
+        4,
+        21,
+        0,
+        0,
+        tzinfo=datetime.timezone.utc,
+    )
+    first_snapshot = CryptoSignalSnapshot(
+        run=CryptoSignalRunRecord(
+            run_timestamp_utc=run_timestamp_utc,
+            runtime_mode='bootstrap',
+            source_name='CMC historical bootstrap',
+            snapshot_version=1,
+            sentiment_now_value=None,
+            sentiment_now_label=None,
+            sentiment_yesterday_value=None,
+            sentiment_last_week_value=None,
+            sentiment_7d_avg=None,
+            sentiment_30d_avg=None,
+            strongest_sector_id=None,
+            strongest_sector_name=None,
+            strongest_sector_avg_price_change_24h=None,
+            strongest_sector_market_change_24h=None,
+            strongest_sector_volume_change_24h=None,
+            strongest_sector_gainers_num=None,
+            strongest_sector_losers_num=None,
+            weakest_sector_id=None,
+            weakest_sector_name=None,
+            weakest_sector_avg_price_change_24h=None,
+            weakest_sector_market_change_24h=None,
+            weakest_sector_volume_change_24h=None,
+            weakest_sector_gainers_num=None,
+            weakest_sector_losers_num=None,
+        ),
+        coins=[
+            CryptoSignalCoinSnapshot(
+                coin_id=1,
+                symbol='BTC',
+                name='Bitcoin',
+                price_usd=95_200.0,
+                price_change_24h=None,
+                volume_24h=31_000_000_000,
+                volume_change_pct_24h=None,
+                is_watchlist=True,
+                context_tags=('watchlist',),
+            )
+        ],
+    )
+    second_snapshot = CryptoSignalSnapshot(
+        run=CryptoSignalRunRecord(
+            run_timestamp_utc=run_timestamp_utc,
+            runtime_mode='bootstrap',
+            source_name='CMC historical bootstrap',
+            snapshot_version=1,
+            sentiment_now_value=None,
+            sentiment_now_label=None,
+            sentiment_yesterday_value=None,
+            sentiment_last_week_value=None,
+            sentiment_7d_avg=None,
+            sentiment_30d_avg=None,
+            strongest_sector_id=None,
+            strongest_sector_name=None,
+            strongest_sector_avg_price_change_24h=None,
+            strongest_sector_market_change_24h=None,
+            strongest_sector_volume_change_24h=None,
+            strongest_sector_gainers_num=None,
+            strongest_sector_losers_num=None,
+            weakest_sector_id=None,
+            weakest_sector_name=None,
+            weakest_sector_avg_price_change_24h=None,
+            weakest_sector_market_change_24h=None,
+            weakest_sector_volume_change_24h=None,
+            weakest_sector_gainers_num=None,
+            weakest_sector_losers_num=None,
+        ),
+        coins=[
+            CryptoSignalCoinSnapshot(
+                coin_id=1027,
+                symbol='ETH',
+                name='Ethereum',
+                price_usd=3_450.0,
+                price_change_24h=1.7,
+                volume_24h=19_000_000_000,
+                volume_change_pct_24h=5.2,
+                is_watchlist=False,
+                context_tags=(),
+            )
+        ],
+    )
+
+    repository.save_or_merge_snapshot(first_snapshot)
+    repository.save_or_merge_snapshot(second_snapshot)
+    repository.save_or_merge_snapshot(first_snapshot)
+    latest_snapshot = repository.get_latest_snapshot()
+
+    assert latest_snapshot is not None
+    assert [coin.symbol for coin in latest_snapshot.coins] == ['BTC', 'ETH']
+
+    connection = sqlite3.connect(tmp_path / 'crypto_signal.sqlite3')
+    run_count = connection.execute(
+        'SELECT COUNT(*) FROM crypto_signal_runs'
+    ).fetchone()[0]
+    coin_count = connection.execute(
+        'SELECT COUNT(*) FROM crypto_signal_coin_snapshots'
+    ).fetchone()[0]
+    connection.close()
+
+    assert run_count == 1
+    assert coin_count == 2
+
+
+def test_get_coin_observation_counts_since_returns_zero_for_missing_coin(tmp_path):
+    repository = CryptoSignalRepository(
+        db_path=str(tmp_path / 'crypto_signal.sqlite3')
+    )
+    snapshot = CryptoSignalSnapshot(
+        run=CryptoSignalRunRecord(
+            run_timestamp_utc=datetime.datetime(
+                2026,
+                4,
+                21,
+                8,
+                45,
+                tzinfo=datetime.timezone.utc,
+            ),
+            runtime_mode='prod',
+            source_name='CMC + Alternative.me',
+            snapshot_version=1,
+            sentiment_now_value=63.0,
+            sentiment_now_label='Greed',
+            sentiment_yesterday_value=58.0,
+            sentiment_last_week_value=49.0,
+            sentiment_7d_avg=55.4,
+            sentiment_30d_avg=51.8,
+            strongest_sector_id='ai-big-data',
+            strongest_sector_name='AI & Big Data',
+            strongest_sector_avg_price_change_24h=8.4,
+            strongest_sector_market_change_24h=6.9,
+            strongest_sector_volume_change_24h=21.7,
+            strongest_sector_gainers_num=18,
+            strongest_sector_losers_num=5,
+            weakest_sector_id='gaming',
+            weakest_sector_name='Gaming',
+            weakest_sector_avg_price_change_24h=-6.1,
+            weakest_sector_market_change_24h=-4.8,
+            weakest_sector_volume_change_24h=-12.3,
+            weakest_sector_gainers_num=4,
+            weakest_sector_losers_num=19,
+        ),
+        coins=[
+            CryptoSignalCoinSnapshot(
+                coin_id=5426,
+                symbol='SOL',
+                name='Solana',
+                price_usd=184.23,
+                price_change_24h=11.4,
+                volume_24h=4_820_000_000,
+                volume_change_pct_24h=27.1,
+                is_watchlist=True,
+                context_tags=('watchlist',),
+            )
+        ],
+    )
+
+    repository.save_snapshot(snapshot)
+    counts = repository.get_coin_observation_counts_since(
+        coin_ids=[1, 5426],
+        start_timestamp_utc=datetime.datetime(
+            2026,
+            4,
+            20,
+            0,
+            0,
+            tzinfo=datetime.timezone.utc,
+        ),
+    )
+
+    assert counts == {
+        1: 0,
+        5426: 1,
+    }

--- a/tests/unit/service/crypto_signal/repository_test.py
+++ b/tests/unit/service/crypto_signal/repository_test.py
@@ -1,0 +1,108 @@
+import datetime
+import sqlite3
+
+from src.service.crypto_signal.models import (
+    CryptoSignalCoinSnapshot,
+    CryptoSignalRunRecord,
+    CryptoSignalSnapshot,
+)
+from src.service.crypto_signal.repository import CryptoSignalRepository
+
+
+def test_save_snapshot_and_load_latest_snapshot(tmp_path):
+    repository = CryptoSignalRepository(
+        db_path=str(tmp_path / 'crypto_signal.sqlite3')
+    )
+    snapshot = CryptoSignalSnapshot(
+        run=CryptoSignalRunRecord(
+            run_timestamp_utc=datetime.datetime(
+                2026,
+                4,
+                21,
+                8,
+                45,
+                tzinfo=datetime.timezone.utc,
+            ),
+            runtime_mode='prod',
+            source_name='CMC + Alternative.me',
+            snapshot_version=1,
+            sentiment_now_value=63.0,
+            sentiment_now_label='Greed',
+            sentiment_yesterday_value=58.0,
+            sentiment_last_week_value=49.0,
+            sentiment_7d_avg=55.4,
+            sentiment_30d_avg=51.8,
+            strongest_sector_id='ai-big-data',
+            strongest_sector_name='AI & Big Data',
+            strongest_sector_avg_price_change_24h=8.4,
+            strongest_sector_market_change_24h=6.9,
+            strongest_sector_volume_change_24h=21.7,
+            strongest_sector_gainers_num=18,
+            strongest_sector_losers_num=5,
+            weakest_sector_id='gaming',
+            weakest_sector_name='Gaming',
+            weakest_sector_avg_price_change_24h=-6.1,
+            weakest_sector_market_change_24h=-4.8,
+            weakest_sector_volume_change_24h=-12.3,
+            weakest_sector_gainers_num=4,
+            weakest_sector_losers_num=19,
+        ),
+        coins=[
+            CryptoSignalCoinSnapshot(
+                coin_id=5426,
+                symbol='SOL',
+                name='Solana',
+                price_usd=184.23,
+                price_change_24h=11.4,
+                volume_24h=4_820_000_000,
+                volume_change_pct_24h=27.1,
+                is_watchlist=True,
+                context_tags=(
+                    'spotlight_trending',
+                    'spotlight_gainer',
+                    'sector_leader_strongest',
+                    'watchlist',
+                ),
+            ),
+            CryptoSignalCoinSnapshot(
+                coin_id=5690,
+                symbol='RENDER',
+                name='Render',
+                price_usd=8.12,
+                price_change_24h=-1.9,
+                volume_24h=286_000_000,
+                volume_change_pct_24h=11.3,
+                is_watchlist=False,
+                context_tags=('sector_loser_strongest',),
+            ),
+        ],
+    )
+
+    saved_snapshot = repository.save_snapshot(snapshot)
+    latest_snapshot = repository.get_latest_snapshot()
+
+    assert saved_snapshot.run.run_id is not None
+    assert latest_snapshot is not None
+    assert latest_snapshot.run.run_timestamp_utc == snapshot.run.run_timestamp_utc
+    assert [coin.symbol for coin in latest_snapshot.coins] == ['RENDER', 'SOL']
+    assert latest_snapshot.coins[1].context_tags == (
+        'spotlight_trending',
+        'spotlight_gainer',
+        'sector_leader_strongest',
+        'watchlist',
+    )
+
+
+def test_init_schema_sets_schema_version_metadata(tmp_path):
+    db_path = tmp_path / 'crypto_signal.sqlite3'
+    repository = CryptoSignalRepository(db_path=str(db_path))
+
+    repository.init_schema()
+
+    connection = sqlite3.connect(db_path)
+    row = connection.execute(
+        "SELECT value FROM crypto_signal_metadata WHERE key = 'schema_version'"
+    ).fetchone()
+    connection.close()
+
+    assert row == ('1',)

--- a/tests/unit/service/crypto_signal/scorer_test.py
+++ b/tests/unit/service/crypto_signal/scorer_test.py
@@ -98,6 +98,7 @@ def test_build_digest_view_emits_score_derived_reason_tags():
         datetime.datetime(2026, 4, 21, 8, 45, tzinfo=datetime.timezone.utc),
         price_change_24h=8.0,
         volume_change_pct_24h=25.0,
+        price_usd=150.0,
         context_tags=(
             'spotlight_trending',
             'spotlight_gainer',
@@ -109,6 +110,7 @@ def test_build_digest_view_emits_score_derived_reason_tags():
         datetime.datetime(2026, 4, 22, 8, 45, tzinfo=datetime.timezone.utc),
         price_change_24h=10.0,
         volume_change_pct_24h=30.0,
+        price_usd=180.0,
         context_tags=(
             'spotlight_trending',
             'spotlight_gainer',
@@ -136,6 +138,7 @@ def test_build_digest_view_emits_score_derived_reason_tags():
         'risk-on',
         'thin-history',
     )
+    assert candidate.window_price_change_pct == 20.0
 
 
 def test_build_digest_view_keeps_watchlist_candidate_from_recent_history_when_latest_snapshot_omits_it():

--- a/tests/unit/service/crypto_signal/scorer_test.py
+++ b/tests/unit/service/crypto_signal/scorer_test.py
@@ -1,0 +1,188 @@
+import datetime
+
+from src.service.crypto_signal.models import (
+    CryptoSignalCoinSnapshot,
+    CryptoSignalRunRecord,
+    CryptoSignalSnapshot,
+)
+from src.service.crypto_signal.scorer import build_digest_view
+
+
+def _build_snapshot(
+    run_timestamp_utc: datetime.datetime,
+    *,
+    price_change_24h: float,
+    volume_change_pct_24h: float,
+    context_tags: tuple[str, ...],
+    is_watchlist: bool = True,
+) -> CryptoSignalSnapshot:
+    return CryptoSignalSnapshot(
+        run=CryptoSignalRunRecord(
+            run_timestamp_utc=run_timestamp_utc,
+            runtime_mode='prod',
+            source_name='CMC + Alternative.me',
+            snapshot_version=1,
+            sentiment_now_value=63.0,
+            sentiment_now_label='Greed',
+            sentiment_yesterday_value=58.0,
+            sentiment_last_week_value=49.0,
+            sentiment_7d_avg=55.4,
+            sentiment_30d_avg=51.8,
+            strongest_sector_id='ai-big-data',
+            strongest_sector_name='AI & Big Data',
+            strongest_sector_avg_price_change_24h=8.4,
+            strongest_sector_market_change_24h=6.9,
+            strongest_sector_volume_change_24h=21.7,
+            strongest_sector_gainers_num=18,
+            strongest_sector_losers_num=5,
+            weakest_sector_id='gaming',
+            weakest_sector_name='Gaming',
+            weakest_sector_avg_price_change_24h=-6.1,
+            weakest_sector_market_change_24h=-4.8,
+            weakest_sector_volume_change_24h=-12.3,
+            weakest_sector_gainers_num=4,
+            weakest_sector_losers_num=19,
+        ),
+        coins=[
+            CryptoSignalCoinSnapshot(
+                coin_id=5426,
+                symbol='SOL',
+                name='Solana',
+                price_usd=184.23,
+                price_change_24h=price_change_24h,
+                volume_24h=4_820_000_000,
+                volume_change_pct_24h=volume_change_pct_24h,
+                is_watchlist=is_watchlist,
+                context_tags=context_tags,
+            )
+        ],
+    )
+
+
+def test_build_digest_view_requires_two_observations_for_strong_signal():
+    latest_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 22, 8, 45, tzinfo=datetime.timezone.utc),
+        price_change_24h=10.0,
+        volume_change_pct_24h=30.0,
+        context_tags=(
+            'spotlight_trending',
+            'spotlight_gainer',
+            'sector_leader_strongest',
+            'watchlist',
+        ),
+    )
+
+    view = build_digest_view(
+        latest_snapshot=latest_snapshot,
+        history=[latest_snapshot],
+        watchlist_coin_ids={5426},
+        window_label='7d',
+        limit=3,
+    )
+
+    assert view.strong_candidates == []
+    assert len(view.watchlist_candidates) == 1
+    candidate = view.watchlist_candidates[0]
+    assert candidate.score == 0
+    assert candidate.observation_count == 1
+    assert candidate.reason_tags == ('risk-on', 'thin-history')
+
+
+def test_build_digest_view_emits_score_derived_reason_tags():
+    earlier_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 21, 8, 45, tzinfo=datetime.timezone.utc),
+        price_change_24h=8.0,
+        volume_change_pct_24h=25.0,
+        context_tags=(
+            'spotlight_trending',
+            'spotlight_gainer',
+            'sector_leader_strongest',
+            'watchlist',
+        ),
+    )
+    latest_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 22, 8, 45, tzinfo=datetime.timezone.utc),
+        price_change_24h=10.0,
+        volume_change_pct_24h=30.0,
+        context_tags=(
+            'spotlight_trending',
+            'spotlight_gainer',
+            'sector_leader_strongest',
+            'watchlist',
+        ),
+    )
+
+    view = build_digest_view(
+        latest_snapshot=latest_snapshot,
+        history=[earlier_snapshot, latest_snapshot],
+        watchlist_coin_ids={5426},
+        window_label='7d',
+        limit=3,
+    )
+
+    assert len(view.strong_candidates) == 1
+    candidate = view.strong_candidates[0]
+    assert candidate.score == 9
+    assert candidate.reason_tags == (
+        'price-up-persistent',
+        'vol-confirm',
+        'spotlight-repeat',
+        'breadth-align',
+        'risk-on',
+        'thin-history',
+    )
+
+
+def test_build_digest_view_keeps_watchlist_candidate_from_recent_history_when_latest_snapshot_omits_it():
+    earlier_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 21, 8, 45, tzinfo=datetime.timezone.utc),
+        price_change_24h=3.4,
+        volume_change_pct_24h=9.8,
+        context_tags=('watchlist',),
+    )
+    latest_snapshot = CryptoSignalSnapshot(
+        run=CryptoSignalRunRecord(
+            run_timestamp_utc=datetime.datetime(2026, 4, 22, 8, 45, tzinfo=datetime.timezone.utc),
+            runtime_mode='prod',
+            source_name='CMC + Alternative.me',
+            snapshot_version=1,
+            sentiment_now_value=63.0,
+            sentiment_now_label='Greed',
+            sentiment_yesterday_value=58.0,
+            sentiment_last_week_value=49.0,
+            sentiment_7d_avg=55.4,
+            sentiment_30d_avg=51.8,
+            strongest_sector_id='ai-big-data',
+            strongest_sector_name='AI & Big Data',
+            strongest_sector_avg_price_change_24h=8.4,
+            strongest_sector_market_change_24h=6.9,
+            strongest_sector_volume_change_24h=21.7,
+            strongest_sector_gainers_num=18,
+            strongest_sector_losers_num=5,
+            weakest_sector_id='gaming',
+            weakest_sector_name='Gaming',
+            weakest_sector_avg_price_change_24h=-6.1,
+            weakest_sector_market_change_24h=-4.8,
+            weakest_sector_volume_change_24h=-12.3,
+            weakest_sector_gainers_num=4,
+            weakest_sector_losers_num=19,
+        ),
+        coins=[],
+    )
+
+    view = build_digest_view(
+        latest_snapshot=latest_snapshot,
+        history=[earlier_snapshot, latest_snapshot],
+        watchlist_coin_ids={5426},
+        window_label='7d',
+        limit=3,
+    )
+
+    assert view.strong_candidates == []
+    assert len(view.watchlist_candidates) == 1
+    candidate = view.watchlist_candidates[0]
+    assert candidate.coin_id == 5426
+    assert candidate.symbol == 'SOL'
+    assert candidate.latest_price_change_24h == 3.4
+    assert candidate.observation_count == 1
+    assert candidate.reason_tags == ('risk-on', 'thin-history')

--- a/tests/unit/service/crypto_signal/scorer_test.py
+++ b/tests/unit/service/crypto_signal/scorer_test.py
@@ -94,6 +94,18 @@ def test_build_digest_view_requires_two_observations_for_strong_signal():
 
 
 def test_build_digest_view_emits_score_derived_reason_tags():
+    oldest_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 20, 8, 45, tzinfo=datetime.timezone.utc),
+        price_change_24h=10.0,
+        volume_change_pct_24h=25.0,
+        price_usd=120.0,
+        context_tags=(
+            'spotlight_trending',
+            'spotlight_gainer',
+            'sector_leader_strongest',
+            'watchlist',
+        ),
+    )
     earlier_snapshot = _build_snapshot(
         datetime.datetime(2026, 4, 21, 8, 45, tzinfo=datetime.timezone.utc),
         price_change_24h=8.0,
@@ -121,7 +133,7 @@ def test_build_digest_view_emits_score_derived_reason_tags():
 
     view = build_digest_view(
         latest_snapshot=latest_snapshot,
-        history=[earlier_snapshot, latest_snapshot],
+        history=[oldest_snapshot, earlier_snapshot, latest_snapshot],
         watchlist_coin_ids={5426},
         window_label='7d',
         limit=3,
@@ -138,7 +150,7 @@ def test_build_digest_view_emits_score_derived_reason_tags():
         'risk-on',
         'thin-history',
     )
-    assert candidate.window_price_change_pct == 20.0
+    assert candidate.window_price_change_pct == 50.0
 
 
 def test_build_digest_view_keeps_watchlist_candidate_from_recent_history_when_latest_snapshot_omits_it():

--- a/tests/unit/service/crypto_signal/scorer_test.py
+++ b/tests/unit/service/crypto_signal/scorer_test.py
@@ -15,6 +15,11 @@ def _build_snapshot(
     volume_change_pct_24h: float,
     context_tags: tuple[str, ...],
     is_watchlist: bool = True,
+    price_usd: float = 184.23,
+    volume_24h: float = 4_820_000_000,
+    coin_id: int = 5426,
+    symbol: str = 'SOL',
+    name: str = 'Solana',
 ) -> CryptoSignalSnapshot:
     return CryptoSignalSnapshot(
         run=CryptoSignalRunRecord(
@@ -45,12 +50,12 @@ def _build_snapshot(
         ),
         coins=[
             CryptoSignalCoinSnapshot(
-                coin_id=5426,
-                symbol='SOL',
-                name='Solana',
-                price_usd=184.23,
+                coin_id=coin_id,
+                symbol=symbol,
+                name=name,
+                price_usd=price_usd,
                 price_change_24h=price_change_24h,
-                volume_24h=4_820_000_000,
+                volume_24h=volume_24h,
                 volume_change_pct_24h=volume_change_pct_24h,
                 is_watchlist=is_watchlist,
                 context_tags=context_tags,
@@ -186,3 +191,85 @@ def test_build_digest_view_keeps_watchlist_candidate_from_recent_history_when_la
     assert candidate.latest_price_change_24h == 3.4
     assert candidate.observation_count == 1
     assert candidate.reason_tags == ('risk-on', 'thin-history')
+
+
+def test_build_digest_view_does_not_emit_confirmation_only_signal_without_price_persistence():
+    earlier_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 21, 8, 45, tzinfo=datetime.timezone.utc),
+        price_change_24h=12.0,
+        volume_change_pct_24h=40.0,
+        context_tags=('spotlight_trending',),
+        coin_id=1337,
+        symbol='BOT',
+        name='Hyperbot',
+        is_watchlist=False,
+        price_usd=0.00019439,
+        volume_24h=0.0,
+    )
+    latest_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 22, 8, 45, tzinfo=datetime.timezone.utc),
+        price_change_24h=-34.7,
+        volume_change_pct_24h=40.0,
+        context_tags=('spotlight_trending',),
+        coin_id=1337,
+        symbol='BOT',
+        name='Hyperbot',
+        is_watchlist=False,
+        price_usd=0.00019439,
+        volume_24h=0.0,
+    )
+
+    view = build_digest_view(
+        latest_snapshot=latest_snapshot,
+        history=[earlier_snapshot, latest_snapshot],
+        watchlist_coin_ids=set(),
+        window_label='7d',
+        limit=3,
+    )
+
+    assert view.strong_candidates == []
+    assert view.weak_candidates == []
+
+
+def test_build_digest_view_filters_dynamic_candidates_below_operator_tradability_floor():
+    earlier_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 21, 8, 45, tzinfo=datetime.timezone.utc),
+        price_change_24h=12.0,
+        volume_change_pct_24h=35.0,
+        context_tags=('spotlight_trending', 'spotlight_gainer'),
+        coin_id=2048,
+        symbol='SPK',
+        name='Spark',
+        is_watchlist=False,
+        price_usd=0.0534,
+        volume_24h=907_602_301.31,
+    )
+    latest_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 22, 8, 45, tzinfo=datetime.timezone.utc),
+        price_change_24h=18.0,
+        volume_change_pct_24h=45.0,
+        context_tags=(
+            'spotlight_trending',
+            'spotlight_gainer',
+            'sector_leader_strongest',
+        ),
+        coin_id=2048,
+        symbol='SPK',
+        name='Spark',
+        is_watchlist=False,
+        price_usd=0.0534,
+        volume_24h=907_602_301.31,
+    )
+
+    view = build_digest_view(
+        latest_snapshot=latest_snapshot,
+        history=[earlier_snapshot, latest_snapshot],
+        watchlist_coin_ids=set(),
+        window_label='7d',
+        tracked_universe_coin_ids=set(),
+        limit=3,
+        min_dynamic_price_usd=1.0,
+        min_dynamic_volume_24h=50_000_000.0,
+    )
+
+    assert view.strong_candidates == []

--- a/tests/unit/service/crypto_signal/snapshot_builder_test.py
+++ b/tests/unit/service/crypto_signal/snapshot_builder_test.py
@@ -56,3 +56,92 @@ def test_build_snapshot_persists_tracked_universe_and_marks_watchlist_subset():
     assert coins_by_id[1].context_tags == ()
     assert coins_by_id[1027].is_watchlist is True
     assert coins_by_id[1027].context_tags == ('watchlist',)
+
+
+def test_build_snapshot_uses_explicit_source_precedence_for_overlapping_coin():
+    coin_id = 999
+    spotlight_coin = cmc_type.TrendingList(
+        id=coin_id,
+        name='Spotlight Name',
+        symbol='SPOT',
+        priceChange=cmc_type.PriceChange(
+            price=1.0,
+            priceChange24h=2.0,
+            volume24h=100_000_000,
+        ),
+    )
+    sector_coin = cmc_type.SectorCoin(
+        id=coin_id,
+        name='Sector Name',
+        slug='sector-name',
+        symbol='SECTOR',
+        quote={
+            'USD': cmc_type.SectorCoinQuote(
+                price=2.0,
+                percent_change_24h=12.0,
+                volume_24h=200_000_000,
+            )
+        },
+    )
+    sector_detail = cmc_type.SectorDetail(
+        sectorId='ai',
+        title='AI',
+        coins=[sector_coin],
+    )
+    sector_coin_detail = cmc_type.CoinDetail(
+        id=coin_id,
+        name='Sector Detail Name',
+        symbol='SDC',
+        volume=300_000_000,
+        volumeChangePercentage24h=22.0,
+        statistics=cmc_type.CoinDetailStatistics(
+            price=3.0,
+            priceChangePercentage24h=13.0,
+        ),
+    )
+    tracked_coin_detail = cmc_type.CoinDetail(
+        id=coin_id,
+        name='Tracked Detail Name',
+        symbol='TRACKED',
+        volume=400_000_000,
+        volumeChangePercentage24h=33.0,
+        statistics=cmc_type.CoinDetailStatistics(
+            price=4.0,
+            priceChangePercentage24h=14.0,
+        ),
+    )
+
+    snapshot = build_snapshot(
+        current=datetime.datetime(2026, 4, 21, 8, 45, tzinfo=datetime.timezone.utc),
+        runtime_mode=RuntimeMode(),
+        source_name='CMC + Alternative.me',
+        sentiment=None,
+        strongest_sector=cmc_type.Sector24hChange(
+            sectorId='ai',
+            title='AI',
+        ),
+        weakest_sector=None,
+        standout_entries=[(spotlight_coin, ['trending'])],
+        standout_coin_details={coin_id: sector_coin_detail},
+        sector_details={'ai': sector_detail},
+        sector_detail_coin_details={coin_id: sector_coin_detail},
+        tracked_universe_entries=[('CONFIGURED', coin_id)],
+        tracked_universe_coin_details={coin_id: tracked_coin_detail},
+        watchlist_entries=[('TRACKED', coin_id)],
+    )
+
+    assert len(snapshot.coins) == 1
+    coin = snapshot.coins[0]
+
+    assert coin.symbol == 'TRACKED'
+    assert coin.name == 'Tracked Detail Name'
+    assert coin.price_usd == 4.0
+    assert coin.price_change_24h == 14.0
+    assert coin.volume_24h == 400_000_000
+    assert coin.volume_change_pct_24h == 33.0
+    assert coin.is_watchlist is True
+    assert coin.context_tags == (
+        'spotlight_trending',
+        'sector_leader_strongest',
+        'watchlist',
+    )

--- a/tests/unit/service/crypto_signal/snapshot_builder_test.py
+++ b/tests/unit/service/crypto_signal/snapshot_builder_test.py
@@ -1,0 +1,58 @@
+import datetime
+
+from market_data_library.types import cmc_type
+
+from src.runtime.runtime_mode import RuntimeMode
+from src.service.crypto_signal.snapshot_builder import build_snapshot
+
+
+def test_build_snapshot_persists_tracked_universe_and_marks_watchlist_subset():
+    btc_detail = cmc_type.CoinDetail(
+        id=1,
+        name='Bitcoin',
+        symbol='BTC',
+        volume=31_000_000_000,
+        volumeChangePercentage24h=7.5,
+        statistics=cmc_type.CoinDetailStatistics(
+            price=95_200.0,
+            priceChangePercentage24h=2.4,
+        ),
+    )
+    eth_detail = cmc_type.CoinDetail(
+        id=1027,
+        name='Ethereum',
+        symbol='ETH',
+        volume=19_000_000_000,
+        volumeChangePercentage24h=5.2,
+        statistics=cmc_type.CoinDetailStatistics(
+            price=3_450.0,
+            priceChangePercentage24h=1.7,
+        ),
+    )
+
+    snapshot = build_snapshot(
+        current=datetime.datetime(2026, 4, 21, 8, 45, tzinfo=datetime.timezone.utc),
+        runtime_mode=RuntimeMode(),
+        source_name='CMC + Alternative.me',
+        sentiment=None,
+        strongest_sector=None,
+        weakest_sector=None,
+        standout_entries=[],
+        standout_coin_details={},
+        sector_details={},
+        sector_detail_coin_details={},
+        tracked_universe_entries=[('BTC', 1), ('ETH', 1027)],
+        tracked_universe_coin_details={
+            1: btc_detail,
+            1027: eth_detail,
+        },
+        watchlist_entries=[('ETH', 1027)],
+    )
+
+    coins_by_id = {coin.coin_id: coin for coin in snapshot.coins}
+
+    assert set(coins_by_id) == {1, 1027}
+    assert coins_by_id[1].is_watchlist is False
+    assert coins_by_id[1].context_tags == ()
+    assert coins_by_id[1027].is_watchlist is True
+    assert coins_by_id[1027].context_tags == ('watchlist',)


### PR DESCRIPTION
## Summary
- Add phase-1 crypto signal persistence and operator-only delivery to the backend.
- Persist normalized crypto digest snapshots in SQLite, bootstrap up to 30d of provider history, and compute explainable stored-history scores.
- Add the scheduled operator signal sender plus a local `crypto_signal_report.py` review path while keeping the public crypto digest contract unchanged.

## Notes
- The backend remains on the Git-installed `market-data-library` dependency; this feature does not require unpublished sibling library changes.
- Signal Telegram delivery resolves to the private operator/admin target and rejects the public crypto channel.
- Dynamic candidate ranking now uses an operator-configurable tradability floor while keeping persisted history broad.

## Validation
- `PYTHONPATH="$(pwd)" poetry run pytest -p no:cacheprovider tests/unit/config/config_test.py tests/unit/service/crypto_signal/backfill_test.py tests/unit/service/crypto_signal/repository_test.py tests/unit/service/crypto_signal/snapshot_builder_test.py tests/unit/service/crypto_signal/scorer_test.py tests/unit/job/crypto/crypto_digest_message_sender_test.py tests/unit/job/crypto/crypto_signal_digest_message_sender_test.py tests/unit/job/crypto/crypto_signal_formatter_test.py tests/unit/job/crypto/crypto_signal_report_test.py tests/unit/job/crypto/crypto_job_test.py tests/unit/notification_destination/telegram_notification_test.py` -> `81 passed, 1 warning`
- `poetry run ruff check --cache-dir /tmp/ruff-cache-crypto-signal-full ...` -> passed for the current crypto-signal runtime and test subset
- `PYTHONPATH="$(pwd)" poetry run python src/job/crypto/crypto_signal_report.py --test_mode=1 --send_telegram=0 --window=7d --limit=3` -> rendered report successfully
- `DISABLE_TELEGRAM=true ENV=dev PYTHONPATH="$(pwd)" poetry run python src/job/crypto/crypto.py --force_run=1` -> completed one live provider-backed prod-runtime smoke run with Telegram disabled
- `ENV=dev PYTHONPATH="$(pwd)" poetry run python src/job/crypto/crypto_signal_report.py --send_telegram=1 --window=7d --limit=3` -> sent one real admin-routed operator report

## Known Follow-up
- Calibrate thresholds, reason tags, and score presentation from private/admin runs before considering phase 2 or any public rollout.
