### PR TITLE
Add Coinalyze crypto market regime context

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -23,6 +23,18 @@ STOCKS_JOB_START_LOCAL_MINUTE=0
 CRYPTO_JOB_START_LOCAL_HOURS=8,16
 CRYPTO_JOB_START_LOCAL_MINUTES=45,15
 JOB_DELAY_TOLERANCE_SECOND=1800
+# Phase-2 BTC market-regime context is disabled by default in tests.
+CRYPTO_SIGNAL_MARKET_REGIME_ENABLED=false
+# Supported runtime provider for this slice. `binance` is reserved for fallback work.
+CRYPTO_SIGNAL_MARKET_REGIME_PROVIDER=coinalyze
+# Keep empty in tracked test config so tests do not initialize a live provider key.
+COINALYZE_API_KEY=
+# Explicit Coinalyze BTC perpetual symbols. Empty keeps collection skipped.
+CRYPTO_SIGNAL_MARKET_REGIME_COINALYZE_SYMBOLS=
+# Coinalyze history interval. Intraday backfill is capped by retained datapoints.
+CRYPTO_SIGNAL_MARKET_REGIME_CADENCE=1hour
+# Historical window for regime summaries. With 1hour cadence, 30d stays under the cap.
+CRYPTO_SIGNAL_MARKET_REGIME_BACKFILL_DAYS=30
 MESSARI_ASSET_METRICS_SHA256=MESSARI_ASSET_METRICS_SHA256
 RESEND_API_KEY=RESEND_API_KEY
 EMAIL_RECIPIENT=EMAIL_RECIPIENT

--- a/README.md
+++ b/README.md
@@ -149,6 +149,18 @@ CRYPTO_SIGNAL_TRACKED_UNIVERSE=BTC,ETH,SOL
 CRYPTO_SIGNAL_WATCHLIST=
 CRYPTO_SIGNAL_DYNAMIC_CANDIDATE_MIN_PRICE_USD=0
 CRYPTO_SIGNAL_DYNAMIC_CANDIDATE_MIN_VOLUME_24H=50000000
+# Optional phase-2 market-regime collection. Disabled unless explicitly enabled.
+CRYPTO_SIGNAL_MARKET_REGIME_ENABLED=false
+# Selected regime provider. Current implemented provider is Coinalyze.
+CRYPTO_SIGNAL_MARKET_REGIME_PROVIDER=coinalyze
+# Required only when market-regime collection is enabled with Coinalyze.
+COINALYZE_API_KEY=...
+# Comma-separated Coinalyze symbols; each must resolve as a BTC perpetual market.
+CRYPTO_SIGNAL_MARKET_REGIME_COINALYZE_SYMBOLS=BTCUSDT_PERP.A,BTCUSD_PERP.0
+# Coinalyze history interval used for OI/funding facts and summaries.
+CRYPTO_SIGNAL_MARKET_REGIME_INTERVAL=1hour
+# Historical window to request; intraday intervals are capped by retained datapoints.
+CRYPTO_SIGNAL_MARKET_REGIME_BACKFILL_DAYS=30
 
 API_AUTH_TOKEN=...
 TRADING_VIEW_WEBHOOK_SECRET=...
@@ -158,6 +170,11 @@ TELEGRAM_READ_TIMEOUT_SECONDS=20
 TELEGRAM_WRITE_TIMEOUT_SECONDS=20
 TELEGRAM_POOL_TIMEOUT_SECONDS=5
 ```
+
+For Coinalyze, configured symbols must resolve through futures metadata as BTC
+perpetual markets before they are stored as BTC regime facts. Intraday
+backfill windows are capped against Coinalyze's documented retained datapoint
+range; use `daily` interval for longer history.
 
 `CRYPTO_SIGNAL_DB_PATH` is relative to the backend process working directory
 when left as the default. In production that default resolves inside the app

--- a/README.md
+++ b/README.md
@@ -266,6 +266,14 @@ SQLite-backed history, deterministic scoring, and a separate operator-only
 signal digest. Phase 1 must stay on private/admin routing; the signal path
 rejects `CRYPTO_TELEGRAM_CHANNEL_ID` as a destination.
 
+Data-provider split:
+- `src/job/crypto/crypto.py` fetches live CoinMarketCap, Alternative.me, and
+  optionally Coinalyze BTC market-regime data, then writes SQLite history.
+- `CryptoSignalDigestMessageSender` and `crypto_signal_report.py` read existing
+  SQLite history; they do not fetch fresh coin or regime provider data.
+- Run `crypto.py` first when you need fresh test-mode signal rows before
+  rendering `crypto_signal_report.py`.
+
 Render the latest stored signal report without sending Telegram:
 
 ```bash

--- a/poetry.lock
+++ b/poetry.lock
@@ -938,8 +938,8 @@ tenacity = "^9.1.2"
 [package.source]
 type = "git"
 url = "ssh://git@github.com/hanchiang/market_data_api.git"
-reference = "1.5.0"
-resolved_reference = "6c20642998e80f440ba67c51d8e65f0488ed5f61"
+reference = "1.6.0"
+resolved_reference = "3716f9428f7cf115a431698342ff47493d03f01a"
 
 [[package]]
 name = "multidict"
@@ -2350,4 +2350,4 @@ redis = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "b79c03a7b90c22596748b3c4fc9cf83b7a11d529f5970ac992a722d6cc7a8ef9"
+content-hash = "9506bec87ecdcff6b21c89ec63ab6b9a3a04ec537b347db9bec31216b252e632"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ pyee = "^9.0.4"
 redis = "^4.4.0"
 python-telegram-bot = {version = "20.3", allow-prereleases = true}
 exchange-calendars = "^4.13.2"
-market-data-library = {git = "ssh://git@github.com/hanchiang/market_data_api.git", rev = "1.5.0"}
+market-data-library = {git = "ssh://git@github.com/hanchiang/market_data_api.git", rev = "1.6.0"}
 
 [tool.poetry.extras]
 redis = ["hiredis"]

--- a/scripts/use_git_market_data_library.sh
+++ b/scripts/use_git_market_data_library.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 git_repo="${MARKET_DATA_LIBRARY_GIT_REPO:-git+ssh://git@github.com/hanchiang/market_data_api.git}"
-git_ref="${MARKET_DATA_LIBRARY_GIT_REF:-1.5.0}"
+git_ref="${MARKET_DATA_LIBRARY_GIT_REF:-1.6.0}"
 
 cd "${repo_root}"
 

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -338,6 +338,102 @@ def get_cryptoquant_api_token() -> str:
 def has_cryptoquant_api_token() -> bool:
     return bool(get_cryptoquant_api_token().strip())
 
+def get_coinalyze_api_key() -> str:
+    return os.getenv('COINALYZE_API_KEY', '')
+
+def has_coinalyze_api_key() -> bool:
+    return bool(get_coinalyze_api_key().strip())
+
+def is_crypto_signal_market_regime_enabled() -> bool:
+    return os.getenv('CRYPTO_SIGNAL_MARKET_REGIME_ENABLED', 'false') == 'true'
+
+def get_crypto_signal_market_regime_provider() -> str:
+    provider = os.getenv(
+        'CRYPTO_SIGNAL_MARKET_REGIME_PROVIDER',
+        'coinalyze',
+    ).strip().lower()
+    if provider not in {'coinalyze', 'binance'}:
+        raise RuntimeError(
+            'CRYPTO_SIGNAL_MARKET_REGIME_PROVIDER must be coinalyze or binance'
+        )
+    return provider
+
+def get_crypto_signal_market_regime_interval() -> str:
+    interval = os.getenv(
+        'CRYPTO_SIGNAL_MARKET_REGIME_INTERVAL',
+        '1hour',
+    ).strip()
+    allowed_intervals = {
+        '1min',
+        '5min',
+        '15min',
+        '30min',
+        '1hour',
+        '2hour',
+        '4hour',
+        '6hour',
+        '12hour',
+        'daily',
+    }
+    if interval not in allowed_intervals:
+        raise RuntimeError(
+            'CRYPTO_SIGNAL_MARKET_REGIME_INTERVAL must be a Coinalyze interval'
+        )
+    return interval
+
+def get_crypto_signal_market_regime_backfill_days() -> int:
+    raw_value = os.getenv('CRYPTO_SIGNAL_MARKET_REGIME_BACKFILL_DAYS', '30')
+    try:
+        value = int(raw_value)
+    except ValueError as error:
+        raise RuntimeError(
+            'CRYPTO_SIGNAL_MARKET_REGIME_BACKFILL_DAYS must be a positive integer'
+        ) from error
+    if value <= 0:
+        raise RuntimeError(
+            'CRYPTO_SIGNAL_MARKET_REGIME_BACKFILL_DAYS must be a positive integer'
+        )
+    interval = get_crypto_signal_market_regime_interval()
+    max_intraday_days = _get_market_regime_max_intraday_backfill_days(interval)
+    if max_intraday_days is not None and value > max_intraday_days:
+        # Coinalyze intraday history is datapoint-limited; rejecting oversized
+        # windows is safer than silently summarizing a partial lookback.
+        raise RuntimeError(
+            'CRYPTO_SIGNAL_MARKET_REGIME_BACKFILL_DAYS exceeds Coinalyze '
+            f'intraday retention for {interval}; maximum is {max_intraday_days} days'
+        )
+    return value
+
+def _get_market_regime_max_intraday_backfill_days(interval: str) -> int | None:
+    interval_minutes = {
+        '1min': 1,
+        '5min': 5,
+        '15min': 15,
+        '30min': 30,
+        '1hour': 60,
+        '2hour': 120,
+        '4hour': 240,
+        '6hour': 360,
+        '12hour': 720,
+    }
+    minutes = interval_minutes.get(interval)
+    if minutes is None:
+        return None
+    return max(1, (1500 * minutes) // (60 * 24))
+
+def get_crypto_signal_market_regime_coinalyze_symbols() -> list[str]:
+    raw_value = os.getenv('CRYPTO_SIGNAL_MARKET_REGIME_COINALYZE_SYMBOLS', '')
+    symbols = [
+        symbol.strip()
+        for symbol in raw_value.split(',')
+        if symbol.strip() != ''
+    ]
+    if len(symbols) > 10:
+        raise RuntimeError(
+            'CRYPTO_SIGNAL_MARKET_REGIME_COINALYZE_SYMBOLS supports at most 10 symbols'
+        )
+    return symbols
+
 _DEFAULT_CRYPTO_SIGNAL_WATCHLIST_IDS = {
     'BTC': 1,
     'ETH': 1027,

--- a/src/data_source/market_data_library.py
+++ b/src/data_source/market_data_library.py
@@ -24,9 +24,12 @@ def init_market_data_api() -> None:
     global crypto_api
     global tradfi_api
     if crypto_api is None:
-        crypto_api = CryptoAPI(
-            cryptoquant_api_token=config.get_cryptoquant_api_token(),
-        )
+        crypto_api_kwargs = {
+            'cryptoquant_api_token': config.get_cryptoquant_api_token(),
+        }
+        if config.has_coinalyze_api_key():
+            crypto_api_kwargs['coinalyze_api_key'] = config.get_coinalyze_api_key()
+        crypto_api = CryptoAPI(**crypto_api_kwargs)
     if tradfi_api is None:
         tradfi_api_kwargs: dict[str, Any] = {
             'is_stealth': config.get_selenium_stealth(),
@@ -50,6 +53,9 @@ async def cleanup_market_data_api() -> None:
         cryptoquant_service = crypto_api.cryptoquant.cryptoquant_service
         if cryptoquant_service is not None:
             await cryptoquant_service.cleanup()
+        coinalyze_service = crypto_api.coinalyze.coinalyze_service
+        if coinalyze_service is not None:
+            await coinalyze_service.cleanup()
 
     if tradfi_api is not None:
         await tradfi_api.barchart.barchart_stocks.cleanup()

--- a/src/job/crypto/crypto_digest_message_sender.py
+++ b/src/job/crypto/crypto_digest_message_sender.py
@@ -16,6 +16,9 @@ from src.job.crypto.crypto_digest_formatter import (
 from src.job.message_sender_wrapper import MessageSenderWrapper
 from src.notification_destination.telegram_notification import send_message_to_admin
 from src.runtime.runtime_mode import DEFAULT_RUNTIME_MODE
+from src.service.crypto_signal.market_regime_collector import (
+    CryptoSignalMarketRegimeCollector,
+)
 from src.service.crypto_signal.backfill import CryptoSignalBackfillService
 from src.service.crypto_signal.repository import CryptoSignalRepository
 from src.service.crypto_signal.snapshot_builder import build_snapshot
@@ -94,6 +97,7 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
                 ),
                 market_data_type=MarketDataType.CRYPTO,
             )
+        await self._persist_market_regime_snapshots(current=current)
 
         digest_message = build_digest_message(
             current=current,
@@ -238,6 +242,48 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
                 should_escape_markdown=True,
             )
         return None
+
+    async def _persist_market_regime_snapshots(
+        self,
+        current,
+    ) -> None:
+        if not config.is_crypto_signal_market_regime_enabled():
+            return
+
+        try:
+            # Regime collection is optional operator context; failures must not
+            # suppress the public digest or the phase-1 signal snapshot.
+            provider = config.get_crypto_signal_market_regime_provider()
+            if provider != 'coinalyze':
+                logger.warning(
+                    'Skipping crypto signal market-regime collection for unsupported provider %s',
+                    provider,
+                )
+                return
+            collector = getattr(self, 'market_regime_collector', None)
+            if collector is None:
+                collector = CryptoSignalMarketRegimeCollector()
+            repository = getattr(self, 'signal_repository', None)
+            if repository is None:
+                repository = CryptoSignalRepository(runtime_mode=self.runtime_mode)
+            snapshots = await collector.collect_coinalyze_btc_snapshots(
+                observed_at_utc=current,
+                runtime_mode=self._runtime_mode_label(),
+                symbols=config.get_crypto_signal_market_regime_coinalyze_symbols(),
+                interval=config.get_crypto_signal_market_regime_interval(),
+                backfill_days=config.get_crypto_signal_market_regime_backfill_days(),
+            )
+            for snapshot in snapshots:
+                repository.save_market_regime_snapshot(snapshot)
+        except Exception:
+            logger.warning(
+                'Crypto signal market-regime collection failed; continuing digest',
+                exc_info=True,
+            )
+
+    def _runtime_mode_label(self) -> str:
+        runtime_mode = getattr(self, 'runtime_mode', DEFAULT_RUNTIME_MODE)
+        return 'test' if runtime_mode.is_test_mode else 'prod'
 
     def _build_backfill_entries(
         self,

--- a/src/job/crypto/crypto_digest_message_sender.py
+++ b/src/job/crypto/crypto_digest_message_sender.py
@@ -43,26 +43,14 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
         market_regime_repository=None,
     ):
         super().__init__(runtime_mode=runtime_mode)
-        self.cmc_service = (
-            Dependencies.get_crypto_stats_service()
-            if cmc_service is None
-            else cmc_service
-        )
-        self.sentiment_service = (
-            Dependencies.get_crypto_sentiment_service()
-            if sentiment_service is None
-            else sentiment_service
-        )
+        self.cmc_service = cmc_service
+        self.sentiment_service = sentiment_service
         self.signal_repository = (
             CryptoSignalRepository(runtime_mode=self.runtime_mode)
             if signal_repository is None
             else signal_repository
         )
-        self.signal_backfill_service = (
-            CryptoSignalBackfillService(cmc_service=self.cmc_service)
-            if signal_backfill_service is None
-            else signal_backfill_service
-        )
+        self.signal_backfill_service = signal_backfill_service
         self.market_regime_collector = market_regime_collector
         self.market_regime_repository = market_regime_repository
         self.tracked_universe_entries = config.get_crypto_signal_tracked_universe()
@@ -77,6 +65,7 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
         return MarketDataType.CRYPTO
 
     async def format_message(self) -> List[str]:
+        self._ensure_runtime_dependencies()
         current = get_current_datetime()
         sentiment = await self.sentiment_service.get_crypto_fear_greed_index()
         strongest_sector, weakest_sector = await self._load_sector_snapshots()
@@ -135,6 +124,16 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
             sector_detail_coin_details=sector_detail_coin_details,
         )
         return [digest_message]
+
+    def _ensure_runtime_dependencies(self) -> None:
+        if self.cmc_service is None:
+            self.cmc_service = Dependencies.get_crypto_stats_service()
+        if self.sentiment_service is None:
+            self.sentiment_service = Dependencies.get_crypto_sentiment_service()
+        if self.signal_backfill_service is None:
+            self.signal_backfill_service = CryptoSignalBackfillService(
+                cmc_service=self.cmc_service
+            )
 
     def _build_signal_snapshot(
         self,

--- a/src/job/crypto/crypto_digest_message_sender.py
+++ b/src/job/crypto/crypto_digest_message_sender.py
@@ -15,7 +15,6 @@ from src.job.crypto.crypto_digest_formatter import (
 )
 from src.job.message_sender_wrapper import MessageSenderWrapper
 from src.notification_destination.telegram_notification import send_message_to_admin
-from src.runtime.runtime_mode import DEFAULT_RUNTIME_MODE
 from src.service.crypto_signal.market_regime_collector import (
     CryptoSignalMarketRegimeCollector,
 )
@@ -44,16 +43,25 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
         market_regime_repository=None,
     ):
         super().__init__(runtime_mode=runtime_mode)
-        self.cmc_service = cmc_service or Dependencies.get_crypto_stats_service()
-        self.sentiment_service = (
-            sentiment_service or Dependencies.get_crypto_sentiment_service()
+        self.cmc_service = (
+            Dependencies.get_crypto_stats_service()
+            if cmc_service is None
+            else cmc_service
         )
-        self.signal_repository = signal_repository or CryptoSignalRepository(
-            runtime_mode=self.runtime_mode
+        self.sentiment_service = (
+            Dependencies.get_crypto_sentiment_service()
+            if sentiment_service is None
+            else sentiment_service
+        )
+        self.signal_repository = (
+            CryptoSignalRepository(runtime_mode=self.runtime_mode)
+            if signal_repository is None
+            else signal_repository
         )
         self.signal_backfill_service = (
-            signal_backfill_service
-            or CryptoSignalBackfillService(cmc_service=self.cmc_service)
+            CryptoSignalBackfillService(cmc_service=self.cmc_service)
+            if signal_backfill_service is None
+            else signal_backfill_service
         )
         self.market_regime_collector = market_regime_collector
         self.market_regime_repository = market_regime_repository
@@ -92,7 +100,7 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
 
         snapshot = self._build_signal_snapshot(
             current=current,
-            runtime_mode=getattr(self, 'runtime_mode', DEFAULT_RUNTIME_MODE),
+            runtime_mode=self.runtime_mode,
             sentiment=sentiment,
             strongest_sector=strongest_sector,
             weakest_sector=weakest_sector,
@@ -285,8 +293,7 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
             )
 
     def _runtime_mode_label(self) -> str:
-        runtime_mode = getattr(self, 'runtime_mode', DEFAULT_RUNTIME_MODE)
-        return 'test' if runtime_mode.is_test_mode else 'prod'
+        return 'test' if self.runtime_mode.is_test_mode else 'prod'
 
     def _build_backfill_entries(
         self,

--- a/src/job/crypto/crypto_digest_message_sender.py
+++ b/src/job/crypto/crypto_digest_message_sender.py
@@ -33,13 +33,30 @@ _SIGNAL_BACKFILL_DAYS = 30
 
 
 class CryptoDigestMessageSender(MessageSenderWrapper):
-    def __init__(self, runtime_mode=None):
+    def __init__(
+        self,
+        runtime_mode=None,
+        cmc_service=None,
+        sentiment_service=None,
+        signal_repository=None,
+        signal_backfill_service=None,
+        market_regime_collector=None,
+        market_regime_repository=None,
+    ):
         super().__init__(runtime_mode=runtime_mode)
-        self.cmc_service = Dependencies.get_crypto_stats_service()
-        self.sentiment_service = Dependencies.get_crypto_sentiment_service()
-        self.signal_repository = CryptoSignalRepository(
+        self.cmc_service = cmc_service or Dependencies.get_crypto_stats_service()
+        self.sentiment_service = (
+            sentiment_service or Dependencies.get_crypto_sentiment_service()
+        )
+        self.signal_repository = signal_repository or CryptoSignalRepository(
             runtime_mode=self.runtime_mode
         )
+        self.signal_backfill_service = (
+            signal_backfill_service
+            or CryptoSignalBackfillService(cmc_service=self.cmc_service)
+        )
+        self.market_regime_collector = market_regime_collector
+        self.market_regime_repository = market_regime_repository
         self.tracked_universe_entries = config.get_crypto_signal_tracked_universe()
         self.watchlist_entries = config.get_crypto_signal_watchlist()
 
@@ -158,16 +175,8 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
         current,
         snapshot,
     ) -> None:
-        repository = getattr(
-            self,
-            'signal_repository',
-            CryptoSignalRepository(runtime_mode=self.runtime_mode),
-        )
-        backfill_service = getattr(
-            self,
-            'signal_backfill_service',
-            CryptoSignalBackfillService(cmc_service=self.cmc_service),
-        )
+        repository = self.signal_repository
+        backfill_service = self.signal_backfill_service
         tracked_universe_entries = getattr(
             self,
             'tracked_universe_entries',
@@ -227,11 +236,7 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
         self,
         snapshot,
     ) -> str | None:
-        repository = getattr(
-            self,
-            'signal_repository',
-            CryptoSignalRepository(runtime_mode=self.runtime_mode),
-        )
+        repository = self.signal_repository
         try:
             repository.save_snapshot(snapshot)
         except Exception as error:
@@ -260,12 +265,10 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
                     provider,
                 )
                 return
-            collector = getattr(self, 'market_regime_collector', None)
+            collector = self.market_regime_collector
             if collector is None:
                 collector = CryptoSignalMarketRegimeCollector()
-            repository = getattr(self, 'signal_repository', None)
-            if repository is None:
-                repository = CryptoSignalRepository(runtime_mode=self.runtime_mode)
+            repository = self.market_regime_repository or self.signal_repository
             snapshots = await collector.collect_coinalyze_btc_snapshots(
                 observed_at_utc=current,
                 runtime_mode=self._runtime_mode_label(),

--- a/src/job/crypto/crypto_signal_digest_message_sender.py
+++ b/src/job/crypto/crypto_signal_digest_message_sender.py
@@ -33,13 +33,27 @@ _SNAPSHOT_FRESHNESS_THRESHOLD = datetime.timedelta(minutes=90)
 
 
 class CryptoSignalDigestMessageSender(MessageSenderWrapper):
-    def __init__(self, runtime_mode=None):
+    def __init__(
+        self,
+        runtime_mode=None,
+        signal_repository=None,
+        watchlist_entries=None,
+        tracked_universe_entries=None,
+    ):
         super().__init__(runtime_mode=runtime_mode)
-        self.signal_repository = CryptoSignalRepository(
+        self.signal_repository = signal_repository or CryptoSignalRepository(
             runtime_mode=self.runtime_mode
         )
-        self.watchlist_entries = config.get_crypto_signal_watchlist()
-        self.tracked_universe_entries = config.get_crypto_signal_tracked_universe()
+        self.watchlist_entries = (
+            config.get_crypto_signal_watchlist()
+            if watchlist_entries is None
+            else watchlist_entries
+        )
+        self.tracked_universe_entries = (
+            config.get_crypto_signal_tracked_universe()
+            if tracked_universe_entries is None
+            else tracked_universe_entries
+        )
 
     @property
     def data_source(self):
@@ -79,11 +93,7 @@ class CryptoSignalDigestMessageSender(MessageSenderWrapper):
             return None
 
     async def format_message(self) -> List[str]:
-        repository = getattr(
-            self,
-            'signal_repository',
-            CryptoSignalRepository(runtime_mode=self.runtime_mode),
-        )
+        repository = self.signal_repository
         latest_snapshot = repository.get_latest_snapshot()
         if latest_snapshot is None:
             return []
@@ -103,12 +113,7 @@ class CryptoSignalDigestMessageSender(MessageSenderWrapper):
             history=history,
             watchlist_coin_ids={coin_id for _symbol, coin_id in self.watchlist_entries},
             tracked_universe_coin_ids={
-                coin_id
-                for _symbol, coin_id in getattr(
-                    self,
-                    'tracked_universe_entries',
-                    config.get_crypto_signal_tracked_universe(),
-                )
+                coin_id for _symbol, coin_id in self.tracked_universe_entries
             },
             window_label=window_label,
             limit=3,

--- a/src/job/crypto/crypto_signal_digest_message_sender.py
+++ b/src/job/crypto/crypto_signal_digest_message_sender.py
@@ -9,7 +9,6 @@ from src.notification_destination.telegram_notification import (
     send_crypto_signal_message,
     send_message_to_admin,
 )
-from src.runtime.runtime_mode import DEFAULT_RUNTIME_MODE
 from src.service.crypto_signal.market_regime import (
     FUNDING_RATE_METRIC,
     OPEN_INTEREST_METRIC,
@@ -41,8 +40,10 @@ class CryptoSignalDigestMessageSender(MessageSenderWrapper):
         tracked_universe_entries=None,
     ):
         super().__init__(runtime_mode=runtime_mode)
-        self.signal_repository = signal_repository or CryptoSignalRepository(
-            runtime_mode=self.runtime_mode
+        self.signal_repository = (
+            CryptoSignalRepository(runtime_mode=self.runtime_mode)
+            if signal_repository is None
+            else signal_repository
         )
         self.watchlist_entries = (
             config.get_crypto_signal_watchlist()
@@ -128,8 +129,7 @@ class CryptoSignalDigestMessageSender(MessageSenderWrapper):
         return [build_crypto_signal_message(view)]
 
     def _is_fresh_enough(self, run_timestamp_utc: datetime.datetime) -> bool:
-        runtime_mode = getattr(self, 'runtime_mode', DEFAULT_RUNTIME_MODE)
-        if runtime_mode.bypass_schedule:
+        if self.runtime_mode.bypass_schedule:
             return True
 
         now_utc = get_current_datetime().astimezone(datetime.timezone.utc)

--- a/src/job/crypto/crypto_signal_digest_message_sender.py
+++ b/src/job/crypto/crypto_signal_digest_message_sender.py
@@ -149,6 +149,8 @@ class CryptoSignalDigestMessageSender(MessageSenderWrapper):
                 return None
             # Operator summaries consume the aggregate basket only; raw venue
             # rows are retained for provenance and later provider comparisons.
+            # Keep this read scope aligned with collector aggregation semantics
+            # so a single raw venue row cannot masquerade as cross-venue context.
             metrics = repository.get_market_regime_metrics(
                 runtime_mode=latest_snapshot.run.runtime_mode,
                 start_timestamp_utc=get_window_start(

--- a/src/job/crypto/crypto_signal_digest_message_sender.py
+++ b/src/job/crypto/crypto_signal_digest_message_sender.py
@@ -10,6 +10,16 @@ from src.notification_destination.telegram_notification import (
     send_message_to_admin,
 )
 from src.runtime.runtime_mode import DEFAULT_RUNTIME_MODE
+from src.service.crypto_signal.market_regime import (
+    FUNDING_RATE_METRIC,
+    OPEN_INTEREST_METRIC,
+    build_market_regime_summary,
+)
+from src.service.crypto_signal.market_regime_collector import (
+    AGGREGATE_INSTRUMENT_SCOPE,
+    AGGREGATE_VENUE_SCOPE,
+    COINALYZE_PROVIDER,
+)
 from src.service.crypto_signal.repository import CryptoSignalRepository
 from src.service.crypto_signal.scorer import build_digest_view, get_window_start
 from src.type.market_data_type import MarketDataType
@@ -104,6 +114,11 @@ class CryptoSignalDigestMessageSender(MessageSenderWrapper):
             limit=3,
             min_dynamic_price_usd=config.get_crypto_signal_dynamic_candidate_min_price_usd(),
             min_dynamic_volume_24h=config.get_crypto_signal_dynamic_candidate_min_volume_24h(),
+            market_regime_summary=self._load_market_regime_summary(
+                repository=repository,
+                latest_snapshot=latest_snapshot,
+                window_label=window_label,
+            ),
         )
         return [build_crypto_signal_message(view)]
 
@@ -115,3 +130,39 @@ class CryptoSignalDigestMessageSender(MessageSenderWrapper):
         now_utc = get_current_datetime().astimezone(datetime.timezone.utc)
         age = now_utc - run_timestamp_utc.astimezone(datetime.timezone.utc)
         return age <= _SNAPSHOT_FRESHNESS_THRESHOLD
+
+    def _load_market_regime_summary(
+        self,
+        *,
+        repository: CryptoSignalRepository,
+        latest_snapshot,
+        window_label: str,
+    ):
+        try:
+            provider = config.get_crypto_signal_market_regime_provider()
+            if provider != COINALYZE_PROVIDER:
+                return None
+            # Operator summaries consume the aggregate basket only; raw venue
+            # rows are retained for provenance and later provider comparisons.
+            metrics = repository.get_market_regime_metrics(
+                runtime_mode=latest_snapshot.run.runtime_mode,
+                start_timestamp_utc=get_window_start(
+                    latest_snapshot,
+                    window_label=window_label,
+                ),
+                end_timestamp_utc=latest_snapshot.run.run_timestamp_utc,
+                metric_names=[OPEN_INTEREST_METRIC, FUNDING_RATE_METRIC],
+                provider=COINALYZE_PROVIDER,
+                venue_scope=AGGREGATE_VENUE_SCOPE,
+                instrument_scope=AGGREGATE_INSTRUMENT_SCOPE,
+                interval=config.get_crypto_signal_market_regime_interval(),
+            )
+        except Exception:
+            logger.warning(
+                'Failed to load crypto signal market-regime summary',
+                exc_info=True,
+            )
+            return None
+        if len(metrics) == 0:
+            return None
+        return build_market_regime_summary(metrics)

--- a/src/job/crypto/crypto_signal_report.py
+++ b/src/job/crypto/crypto_signal_report.py
@@ -9,11 +9,55 @@ from src.notification_destination.telegram_notification import (
     send_crypto_signal_message,
 )
 from src.runtime.runtime_mode import RuntimeMode
+from src.service.crypto_signal.market_regime import (
+    FUNDING_RATE_METRIC,
+    OPEN_INTEREST_METRIC,
+    build_market_regime_summary,
+)
+from src.service.crypto_signal.market_regime_collector import (
+    AGGREGATE_INSTRUMENT_SCOPE,
+    AGGREGATE_VENUE_SCOPE,
+    COINALYZE_PROVIDER,
+)
 from src.service.crypto_signal.repository import CryptoSignalRepository
 from src.service.crypto_signal.scorer import build_digest_view, get_window_start
 
 
 logger = logging.getLogger('Crypto signal report')
+
+
+def _load_market_regime_summary(
+    *,
+    repository: CryptoSignalRepository,
+    latest_snapshot,
+    window_label: str,
+):
+    try:
+        provider = config.get_crypto_signal_market_regime_provider()
+        if provider != COINALYZE_PROVIDER:
+            return None
+        metrics = repository.get_market_regime_metrics(
+            runtime_mode=latest_snapshot.run.runtime_mode,
+            start_timestamp_utc=get_window_start(
+                latest_snapshot,
+                window_label=window_label,
+            ),
+            end_timestamp_utc=latest_snapshot.run.run_timestamp_utc,
+            metric_names=[OPEN_INTEREST_METRIC, FUNDING_RATE_METRIC],
+            provider=COINALYZE_PROVIDER,
+            venue_scope=AGGREGATE_VENUE_SCOPE,
+            instrument_scope=AGGREGATE_INSTRUMENT_SCOPE,
+            interval=config.get_crypto_signal_market_regime_interval(),
+        )
+    except Exception:
+        logger.warning(
+            'Failed to load crypto signal market-regime summary',
+            exc_info=True,
+        )
+        return None
+    if len(metrics) == 0:
+        return None
+    return build_market_regime_summary(metrics)
 
 
 async def main() -> None:
@@ -62,6 +106,11 @@ Phase-1 safety:
         limit=args.limit,
         min_dynamic_price_usd=config.get_crypto_signal_dynamic_candidate_min_price_usd(),
         min_dynamic_volume_24h=config.get_crypto_signal_dynamic_candidate_min_volume_24h(),
+        market_regime_summary=_load_market_regime_summary(
+            repository=repository,
+            latest_snapshot=latest_snapshot,
+            window_label=args.window,
+        ),
     )
     message = build_crypto_signal_message(view)
     print(message)

--- a/src/job/crypto/crypto_signal_report.py
+++ b/src/job/crypto/crypto_signal_report.py
@@ -36,6 +36,8 @@ def _load_market_regime_summary(
         provider = config.get_crypto_signal_market_regime_provider()
         if provider != COINALYZE_PROVIDER:
             return None
+        # Match the scheduled operator digest: report output should describe
+        # the BTC perpetual basket, not whichever raw venue rows are present.
         metrics = repository.get_market_regime_metrics(
             runtime_mode=latest_snapshot.run.runtime_mode,
             start_timestamp_utc=get_window_start(

--- a/src/service/crypto/coinalyze.py
+++ b/src/service/crypto/coinalyze.py
@@ -1,5 +1,3 @@
-from typing import Final, cast
-
 from market_data_library.core.crypto.coinalyze.coinalyze import (
     CoinalyzeService as MarketDataCoinalyzeService,
 )
@@ -11,23 +9,19 @@ from market_data_library.core.crypto.coinalyze.type import (
 from src.data_source.market_data_library import get_crypto_api
 
 
-_DEFAULT_COINALYZE_SERVICE: Final = object()
-
-
 class CoinalyzeService:
     def __init__(
         self,
-        coinalyze_service: MarketDataCoinalyzeService
-        | None
-        | object = _DEFAULT_COINALYZE_SERVICE,
+        coinalyze_service: MarketDataCoinalyzeService | None = None,
+        *,
+        use_configured_service: bool = True,
     ) -> None:
-        if coinalyze_service is _DEFAULT_COINALYZE_SERVICE:
+        if coinalyze_service is not None:
+            self.coinalyze_service = coinalyze_service
+        elif use_configured_service:
             self.coinalyze_service = get_crypto_api().coinalyze.coinalyze_service
         else:
-            self.coinalyze_service = cast(
-                MarketDataCoinalyzeService | None,
-                coinalyze_service,
-            )
+            self.coinalyze_service = None
 
     def is_configured(self) -> bool:
         return self.coinalyze_service is not None

--- a/src/service/crypto/coinalyze.py
+++ b/src/service/crypto/coinalyze.py
@@ -1,0 +1,72 @@
+from typing import Final, cast
+
+from market_data_library.core.crypto.coinalyze.coinalyze import (
+    CoinalyzeService as MarketDataCoinalyzeService,
+)
+from market_data_library.core.crypto.coinalyze.type import (
+    CoinalyzeFutureMarket,
+    CoinalyzeHistorySeries,
+)
+
+from src.data_source.market_data_library import get_crypto_api
+
+
+_DEFAULT_COINALYZE_SERVICE: Final = object()
+
+
+class CoinalyzeService:
+    def __init__(
+        self,
+        coinalyze_service: MarketDataCoinalyzeService
+        | None
+        | object = _DEFAULT_COINALYZE_SERVICE,
+    ) -> None:
+        if coinalyze_service is _DEFAULT_COINALYZE_SERVICE:
+            self.coinalyze_service = get_crypto_api().coinalyze.coinalyze_service
+        else:
+            self.coinalyze_service = cast(
+                MarketDataCoinalyzeService | None,
+                coinalyze_service,
+            )
+
+    def is_configured(self) -> bool:
+        return self.coinalyze_service is not None
+
+    async def get_future_markets(self) -> list[CoinalyzeFutureMarket]:
+        if self.coinalyze_service is None:
+            raise RuntimeError('COINALYZE_API_KEY is not configured')
+        return await self.coinalyze_service.get_future_markets()
+
+    async def get_open_interest_history(
+        self,
+        symbols: list[str],
+        interval: str,
+        from_timestamp_seconds: int,
+        to_timestamp_seconds: int,
+        convert_to_usd: bool = True,
+    ) -> list[CoinalyzeHistorySeries]:
+        if self.coinalyze_service is None:
+            raise RuntimeError('COINALYZE_API_KEY is not configured')
+        return await self.coinalyze_service.get_open_interest_history(
+            symbols=symbols,
+            interval=interval,
+            from_timestamp_seconds=from_timestamp_seconds,
+            to_timestamp_seconds=to_timestamp_seconds,
+            convert_to_usd=convert_to_usd,
+        )
+
+    async def get_funding_rate_history(
+        self,
+        symbols: list[str],
+        interval: str,
+        from_timestamp_seconds: int,
+        to_timestamp_seconds: int,
+    ) -> list[CoinalyzeHistorySeries]:
+        if self.coinalyze_service is None:
+            raise RuntimeError('COINALYZE_API_KEY is not configured')
+        return await self.coinalyze_service.get_funding_rate_history(
+            symbols=symbols,
+            interval=interval,
+            from_timestamp_seconds=from_timestamp_seconds,
+            to_timestamp_seconds=to_timestamp_seconds,
+        )

--- a/src/service/crypto_signal/market_regime.py
+++ b/src/service/crypto_signal/market_regime.py
@@ -1,0 +1,79 @@
+from statistics import mean
+
+from src.service.crypto_signal.models import (
+    CryptoSignalMarketRegimeMetric,
+    CryptoSignalMarketRegimeSummary,
+)
+
+
+OPEN_INTEREST_METRIC = 'open_interest_usd'
+FUNDING_RATE_METRIC = 'funding_rate'
+
+
+def build_market_regime_summary(
+    metrics: list[CryptoSignalMarketRegimeMetric],
+) -> CryptoSignalMarketRegimeSummary:
+    open_interest_values = _metric_values(metrics, OPEN_INTEREST_METRIC)
+    funding_values = _metric_values(metrics, FUNDING_RATE_METRIC)
+
+    if len(open_interest_values) < 2:
+        return CryptoSignalMarketRegimeSummary(
+            label='Insufficient regime history',
+            reason='open interest history unavailable',
+        )
+
+    oi_start = open_interest_values[0]
+    oi_end = open_interest_values[-1]
+    oi_change_pct = _pct_change(start=oi_start, end=oi_end)
+    avg_funding = mean(funding_values) if funding_values else None
+
+    if oi_change_pct is None:
+        return CryptoSignalMarketRegimeSummary(
+            label='Insufficient regime history',
+            reason='open interest baseline unavailable',
+        )
+
+    funding_reason = (
+        'funding unavailable'
+        if avg_funding is None
+        else f'avg funding {avg_funding:+.4f}%'
+    )
+    reason = f'OI {oi_change_pct:+.1f}%, {funding_reason}'
+
+    if avg_funding is not None and avg_funding >= 0.03:
+        return CryptoSignalMarketRegimeSummary(
+            label='Crowded long pressure',
+            reason=reason,
+        )
+    if oi_change_pct >= 5:
+        return CryptoSignalMarketRegimeSummary(
+            label='Leverage building',
+            reason=reason,
+        )
+    if oi_change_pct <= -5:
+        return CryptoSignalMarketRegimeSummary(
+            label='Deleveraging',
+            reason=reason,
+        )
+    return CryptoSignalMarketRegimeSummary(label='Mixed', reason=reason)
+
+
+def _metric_values(
+    metrics: list[CryptoSignalMarketRegimeMetric],
+    metric_name: str,
+) -> list[float]:
+    sorted_metrics = sorted(
+        (
+            metric
+            for metric in metrics
+            if metric.metric_name == metric_name and metric.metric_value is not None
+        ),
+        key=lambda metric: metric.source_timestamp_utc,
+    )
+    return [float(metric.metric_value) for metric in sorted_metrics]
+
+
+def _pct_change(start: float, end: float) -> float | None:
+    if start == 0:
+        return None
+    return ((end - start) / abs(start)) * 100

--- a/src/service/crypto_signal/market_regime.py
+++ b/src/service/crypto_signal/market_regime.py
@@ -40,11 +40,15 @@ def build_market_regime_summary(
     )
     reason = f'OI {oi_change_pct:+.1f}%, {funding_reason}'
 
+    # Funding crowding takes precedence over OI direction because expensive
+    # longs can make an otherwise constructive OI build fragile.
     if avg_funding is not None and avg_funding >= 0.03:
         return CryptoSignalMarketRegimeSummary(
             label='Crowded long pressure',
             reason=reason,
         )
+    # Phase 2A uses conservative OI thresholds so the label changes only when
+    # positioning clearly moves, leaving mild or conflicting context as Mixed.
     if oi_change_pct >= 5:
         return CryptoSignalMarketRegimeSummary(
             label='Leverage building',

--- a/src/service/crypto_signal/market_regime_collector.py
+++ b/src/service/crypto_signal/market_regime_collector.py
@@ -236,6 +236,8 @@ class CryptoSignalMarketRegimeCollector:
         series: _MetricSeries,
     ) -> CryptoSignalMarketRegimeSnapshot:
         metrics = [
+            # OI is additive across venues once converted to USD; funding is a
+            # rate, so the first slice averages it rather than summing.
             *self._build_aggregate_metrics(
                 metric_name=OPEN_INTEREST_METRIC,
                 unit='usd',

--- a/src/service/crypto_signal/market_regime_collector.py
+++ b/src/service/crypto_signal/market_regime_collector.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
+from typing import Protocol
 
 from market_data_library.core.crypto.coinalyze.type import (
     CoinalyzeFutureMarket,
@@ -9,7 +10,7 @@ from market_data_library.core.crypto.coinalyze.type import (
     CoinalyzeHistorySeries,
 )
 
-from src.data_source.market_data_library import get_crypto_api
+from src.service.crypto.coinalyze import CoinalyzeService
 from src.service.crypto_signal.market_regime import (
     FUNDING_RATE_METRIC,
     OPEN_INTEREST_METRIC,
@@ -34,8 +35,34 @@ class _MetricSeries:
     funding_by_symbol: dict[str, CoinalyzeHistorySeries]
 
 
+class _CoinalyzeMarketRegimeService(Protocol):
+    async def get_future_markets(self) -> list[CoinalyzeFutureMarket]:
+        ...
+
+    async def get_open_interest_history(
+        self,
+        symbols: list[str],
+        interval: str,
+        from_timestamp_seconds: int,
+        to_timestamp_seconds: int,
+        convert_to_usd: bool = True,
+    ) -> list[CoinalyzeHistorySeries]:
+        ...
+
+    async def get_funding_rate_history(
+        self,
+        symbols: list[str],
+        interval: str,
+        from_timestamp_seconds: int,
+        to_timestamp_seconds: int,
+    ) -> list[CoinalyzeHistorySeries]:
+        ...
+
+
 class CryptoSignalMarketRegimeCollector:
-    def __init__(self, coinalyze_service=None) -> None:
+    def __init__(
+        self, coinalyze_service: _CoinalyzeMarketRegimeService | None = None
+    ) -> None:
         self.coinalyze_service = coinalyze_service
 
     async def collect_coinalyze_btc_snapshots(
@@ -98,8 +125,8 @@ class CryptoSignalMarketRegimeCollector:
         raw_snapshots = [
             snapshot for snapshot in raw_snapshots if len(snapshot.metrics) > 0
         ]
-        # Persist raw venue facts for auditability, then summarize only the
-        # aggregate basket so operator output is not biased toward one venue.
+        # Raw venue facts preserve provenance for audits and later provider
+        # comparisons; operator output reads only the aggregate basket.
         aggregate_snapshot = self._build_aggregate_snapshot(
             observed_at_utc=observed_at_utc,
             runtime_mode=runtime_mode,
@@ -110,15 +137,18 @@ class CryptoSignalMarketRegimeCollector:
             return raw_snapshots
         return [*raw_snapshots, aggregate_snapshot]
 
-    def _get_coinalyze_service(self):
+    def _get_coinalyze_service(self) -> _CoinalyzeMarketRegimeService | None:
         if self.coinalyze_service is not None:
             return self.coinalyze_service
-        return get_crypto_api().coinalyze.coinalyze_service
+        coinalyze_service = CoinalyzeService()
+        if not coinalyze_service.is_configured():
+            return None
+        return coinalyze_service
 
     async def _load_market_metadata(
         self,
         *,
-        coinalyze_service,
+        coinalyze_service: _CoinalyzeMarketRegimeService,
         symbols: list[str],
     ) -> dict[str, CoinalyzeFutureMarket]:
         try:
@@ -168,7 +198,7 @@ class CryptoSignalMarketRegimeCollector:
     async def _load_metric_series(
         self,
         *,
-        coinalyze_service,
+        coinalyze_service: _CoinalyzeMarketRegimeService,
         symbols: list[str],
         interval: str,
         from_timestamp_seconds: int,
@@ -294,11 +324,15 @@ class CryptoSignalMarketRegimeCollector:
         values_by_timestamp = defaultdict(list)
         for series in series_by_symbol.values():
             for point in series.history:
+                # Aggregate only facts observed for the same provider timestamp;
+                # carrying forward stale venue values would invent precision.
                 values_by_timestamp[point.t].append(point.c)
 
         metrics = []
         for timestamp in sorted(values_by_timestamp):
             values = values_by_timestamp[timestamp]
+            # OI is a notional exposure pool and can be summed across venues.
+            # Funding is a rate, so basket context uses an equal-weight mean.
             metric_value = (
                 sum(values)
                 if aggregation == 'sum'

--- a/src/service/crypto_signal/market_regime_collector.py
+++ b/src/service/crypto_signal/market_regime_collector.py
@@ -1,0 +1,321 @@
+import datetime
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+
+from market_data_library.core.crypto.coinalyze.type import (
+    CoinalyzeFutureMarket,
+    CoinalyzeHistoryPoint,
+    CoinalyzeHistorySeries,
+)
+
+from src.data_source.market_data_library import get_crypto_api
+from src.service.crypto_signal.market_regime import (
+    FUNDING_RATE_METRIC,
+    OPEN_INTEREST_METRIC,
+)
+from src.service.crypto_signal.models import (
+    CryptoSignalMarketRegimeMetric,
+    CryptoSignalMarketRegimeSnapshot,
+)
+
+
+logger = logging.getLogger('Crypto signal market regime collector')
+COINALYZE_PROVIDER = 'coinalyze'
+BTC_ASSET_SYMBOL = 'BTC'
+AGGREGATE_VENUE_SCOPE = 'aggregate'
+AGGREGATE_INSTRUMENT_SCOPE = 'btc_perpetual_basket'
+SOURCE_PAYLOAD_VERSION = 1
+
+
+@dataclass(slots=True)
+class _MetricSeries:
+    open_interest_by_symbol: dict[str, CoinalyzeHistorySeries]
+    funding_by_symbol: dict[str, CoinalyzeHistorySeries]
+
+
+class CryptoSignalMarketRegimeCollector:
+    def __init__(self, coinalyze_service=None) -> None:
+        self.coinalyze_service = coinalyze_service
+
+    async def collect_coinalyze_btc_snapshots(
+        self,
+        *,
+        observed_at_utc: datetime.datetime,
+        runtime_mode: str,
+        symbols: list[str],
+        interval: str,
+        backfill_days: int,
+    ) -> list[CryptoSignalMarketRegimeSnapshot]:
+        coinalyze_service = self._get_coinalyze_service()
+        if coinalyze_service is None:
+            logger.warning('Skipping Coinalyze market-regime collection: API key absent')
+            return []
+        if len(symbols) == 0:
+            logger.warning('Skipping Coinalyze market-regime collection: no symbols configured')
+            return []
+
+        observed_at_utc = observed_at_utc.astimezone(datetime.timezone.utc)
+        from_timestamp_seconds = int(
+            (observed_at_utc - datetime.timedelta(days=backfill_days)).timestamp()
+        )
+        to_timestamp_seconds = int(observed_at_utc.timestamp())
+        metadata_by_symbol = await self._load_market_metadata(
+            coinalyze_service=coinalyze_service,
+            symbols=symbols,
+        )
+        # Metadata is the guardrail that prevents ETH or dated futures from
+        # being mislabeled as BTC regime context, so missing metadata fails closed.
+        selected_symbols = self._filter_btc_perpetual_symbols(
+            symbols=symbols,
+            metadata_by_symbol=metadata_by_symbol,
+        )
+        if len(selected_symbols) == 0:
+            logger.warning(
+                'Skipping Coinalyze market-regime collection: no configured BTC perpetual symbols'
+            )
+            return []
+        series = await self._load_metric_series(
+            coinalyze_service=coinalyze_service,
+            symbols=selected_symbols,
+            interval=interval,
+            from_timestamp_seconds=from_timestamp_seconds,
+            to_timestamp_seconds=to_timestamp_seconds,
+        )
+
+        raw_snapshots = [
+            self._build_raw_snapshot(
+                observed_at_utc=observed_at_utc,
+                runtime_mode=runtime_mode,
+                symbol=symbol,
+                market=metadata_by_symbol.get(symbol),
+                interval=interval,
+                open_interest_series=series.open_interest_by_symbol.get(symbol),
+                funding_series=series.funding_by_symbol.get(symbol),
+            )
+            for symbol in selected_symbols
+        ]
+        raw_snapshots = [
+            snapshot for snapshot in raw_snapshots if len(snapshot.metrics) > 0
+        ]
+        # Persist raw venue facts for auditability, then summarize only the
+        # aggregate basket so operator output is not biased toward one venue.
+        aggregate_snapshot = self._build_aggregate_snapshot(
+            observed_at_utc=observed_at_utc,
+            runtime_mode=runtime_mode,
+            interval=interval,
+            series=series,
+        )
+        if len(aggregate_snapshot.metrics) == 0:
+            return raw_snapshots
+        return [*raw_snapshots, aggregate_snapshot]
+
+    def _get_coinalyze_service(self):
+        if self.coinalyze_service is not None:
+            return self.coinalyze_service
+        return get_crypto_api().coinalyze.coinalyze_service
+
+    async def _load_market_metadata(
+        self,
+        *,
+        coinalyze_service,
+        symbols: list[str],
+    ) -> dict[str, CoinalyzeFutureMarket]:
+        try:
+            markets = await coinalyze_service.get_future_markets()
+        except Exception:
+            logger.warning(
+                'Failed to load Coinalyze futures metadata; skipping market-regime collection',
+                exc_info=True,
+            )
+            return {}
+        requested_symbols = set(symbols)
+        return {
+            market.symbol: market
+            for market in markets
+            if market.symbol in requested_symbols
+        }
+
+    def _filter_btc_perpetual_symbols(
+        self,
+        *,
+        symbols: list[str],
+        metadata_by_symbol: dict[str, CoinalyzeFutureMarket],
+    ) -> list[str]:
+        # A blank map means metadata was unavailable, not that every configured
+        # symbol is valid for the BTC perpetual basket.
+        if len(metadata_by_symbol) == 0:
+            return []
+
+        selected_symbols = []
+        for symbol in symbols:
+            market = metadata_by_symbol.get(symbol)
+            if market is None:
+                logger.warning(
+                    'Dropping Coinalyze market-regime symbol %s: futures metadata missing',
+                    symbol,
+                )
+                continue
+            if market.base_asset.upper() != BTC_ASSET_SYMBOL or not market.is_perpetual:
+                logger.warning(
+                    'Dropping Coinalyze market-regime symbol %s: not a BTC perpetual',
+                    symbol,
+                )
+                continue
+            selected_symbols.append(symbol)
+        return selected_symbols
+
+    async def _load_metric_series(
+        self,
+        *,
+        coinalyze_service,
+        symbols: list[str],
+        interval: str,
+        from_timestamp_seconds: int,
+        to_timestamp_seconds: int,
+    ) -> _MetricSeries:
+        open_interest = await coinalyze_service.get_open_interest_history(
+            symbols=symbols,
+            interval=interval,
+            from_timestamp_seconds=from_timestamp_seconds,
+            to_timestamp_seconds=to_timestamp_seconds,
+            convert_to_usd=True,
+        )
+        funding = await coinalyze_service.get_funding_rate_history(
+            symbols=symbols,
+            interval=interval,
+            from_timestamp_seconds=from_timestamp_seconds,
+            to_timestamp_seconds=to_timestamp_seconds,
+        )
+        return _MetricSeries(
+            open_interest_by_symbol={entry.symbol: entry for entry in open_interest},
+            funding_by_symbol={entry.symbol: entry for entry in funding},
+        )
+
+    def _build_raw_snapshot(
+        self,
+        *,
+        observed_at_utc: datetime.datetime,
+        runtime_mode: str,
+        symbol: str,
+        market: CoinalyzeFutureMarket | None,
+        interval: str,
+        open_interest_series: CoinalyzeHistorySeries | None,
+        funding_series: CoinalyzeHistorySeries | None,
+    ) -> CryptoSignalMarketRegimeSnapshot:
+        metrics = [
+            *self._build_metrics(
+                metric_name=OPEN_INTEREST_METRIC,
+                unit='usd',
+                points=[] if open_interest_series is None else open_interest_series.history,
+            ),
+            *self._build_metrics(
+                metric_name=FUNDING_RATE_METRIC,
+                unit='percent',
+                points=[] if funding_series is None else funding_series.history,
+            ),
+        ]
+        return CryptoSignalMarketRegimeSnapshot(
+            observed_at_utc=observed_at_utc,
+            runtime_mode=runtime_mode,
+            provider=COINALYZE_PROVIDER,
+            asset_symbol=BTC_ASSET_SYMBOL,
+            venue_scope=self._venue_scope(market=market),
+            instrument_scope=symbol,
+            interval=interval,
+            source_payload_version=SOURCE_PAYLOAD_VERSION,
+            metrics=metrics,
+        )
+
+    def _build_aggregate_snapshot(
+        self,
+        *,
+        observed_at_utc: datetime.datetime,
+        runtime_mode: str,
+        interval: str,
+        series: _MetricSeries,
+    ) -> CryptoSignalMarketRegimeSnapshot:
+        metrics = [
+            *self._build_aggregate_metrics(
+                metric_name=OPEN_INTEREST_METRIC,
+                unit='usd',
+                series_by_symbol=series.open_interest_by_symbol,
+                aggregation='sum',
+            ),
+            *self._build_aggregate_metrics(
+                metric_name=FUNDING_RATE_METRIC,
+                unit='percent',
+                series_by_symbol=series.funding_by_symbol,
+                aggregation='mean',
+            ),
+        ]
+        return CryptoSignalMarketRegimeSnapshot(
+            observed_at_utc=observed_at_utc,
+            runtime_mode=runtime_mode,
+            provider=COINALYZE_PROVIDER,
+            asset_symbol=BTC_ASSET_SYMBOL,
+            venue_scope=AGGREGATE_VENUE_SCOPE,
+            instrument_scope=AGGREGATE_INSTRUMENT_SCOPE,
+            interval=interval,
+            source_payload_version=SOURCE_PAYLOAD_VERSION,
+            metrics=metrics,
+        )
+
+    def _build_metrics(
+        self,
+        *,
+        metric_name: str,
+        unit: str,
+        points: list[CoinalyzeHistoryPoint],
+    ) -> list[CryptoSignalMarketRegimeMetric]:
+        return [
+            CryptoSignalMarketRegimeMetric(
+                metric_name=metric_name,
+                metric_value=point.c,
+                unit=unit,
+                source_timestamp_utc=datetime.datetime.fromtimestamp(
+                    point.t,
+                    tz=datetime.timezone.utc,
+                ),
+            )
+            for point in points
+        ]
+
+    def _build_aggregate_metrics(
+        self,
+        *,
+        metric_name: str,
+        unit: str,
+        series_by_symbol: dict[str, CoinalyzeHistorySeries],
+        aggregation: str,
+    ) -> list[CryptoSignalMarketRegimeMetric]:
+        values_by_timestamp = defaultdict(list)
+        for series in series_by_symbol.values():
+            for point in series.history:
+                values_by_timestamp[point.t].append(point.c)
+
+        metrics = []
+        for timestamp in sorted(values_by_timestamp):
+            values = values_by_timestamp[timestamp]
+            metric_value = (
+                sum(values)
+                if aggregation == 'sum'
+                else sum(values) / len(values)
+            )
+            metrics.append(
+                CryptoSignalMarketRegimeMetric(
+                    metric_name=metric_name,
+                    metric_value=metric_value,
+                    unit=unit,
+                    source_timestamp_utc=datetime.datetime.fromtimestamp(
+                        timestamp,
+                        tz=datetime.timezone.utc,
+                    ),
+                )
+            )
+        return metrics
+
+    def _venue_scope(self, market: CoinalyzeFutureMarket | None) -> str:
+        if market is None or market.exchange == '':
+            return 'unknown'
+        return market.exchange.lower()

--- a/src/service/crypto_signal/models.py
+++ b/src/service/crypto_signal/models.py
@@ -54,6 +54,42 @@ class CryptoSignalSnapshot:
 
 
 @dataclass(slots=True)
+class CryptoSignalMarketRegimeMetric:
+    metric_name: str
+    metric_value: float | None
+    unit: str
+    source_timestamp_utc: datetime.datetime
+    provider: str | None = None
+    asset_symbol: str | None = None
+    venue_scope: str | None = None
+    instrument_scope: str | None = None
+    cadence: str | None = None
+    snapshot_id: int | None = None
+    created_at_utc: datetime.datetime | None = None
+
+
+@dataclass(slots=True)
+class CryptoSignalMarketRegimeSnapshot:
+    observed_at_utc: datetime.datetime
+    runtime_mode: str
+    provider: str
+    asset_symbol: str
+    venue_scope: str
+    instrument_scope: str
+    cadence: str
+    source_payload_version: int
+    metrics: list[CryptoSignalMarketRegimeMetric] = field(default_factory=list)
+    snapshot_id: int | None = None
+    created_at_utc: datetime.datetime | None = None
+
+
+@dataclass(slots=True)
+class CryptoSignalMarketRegimeSummary:
+    label: str
+    reason: str
+
+
+@dataclass(slots=True)
 class CryptoSignalCandidate:
     coin_id: int
     symbol: str

--- a/src/service/crypto_signal/models.py
+++ b/src/service/crypto_signal/models.py
@@ -63,7 +63,7 @@ class CryptoSignalMarketRegimeMetric:
     asset_symbol: str | None = None
     venue_scope: str | None = None
     instrument_scope: str | None = None
-    cadence: str | None = None
+    interval: str | None = None
     snapshot_id: int | None = None
     created_at_utc: datetime.datetime | None = None
 
@@ -76,7 +76,7 @@ class CryptoSignalMarketRegimeSnapshot:
     asset_symbol: str
     venue_scope: str
     instrument_scope: str
-    cadence: str
+    interval: str
     source_payload_version: int
     metrics: list[CryptoSignalMarketRegimeMetric] = field(default_factory=list)
     snapshot_id: int | None = None

--- a/src/service/crypto_signal/repository.py
+++ b/src/service/crypto_signal/repository.py
@@ -71,7 +71,7 @@ SCHEMA_DOCS = {
         'asset_symbol': 'Benchmark asset symbol, initially BTC.',
         'venue_scope': 'Exchange or aggregate venue scope.',
         'instrument_scope': 'Provider instrument scope or symbol.',
-        'cadence': 'Sampling cadence for the stored metrics.',
+        'interval': 'Sampling interval for the stored metrics.',
         'source_payload_version': 'Provider payload mapping version.',
         'created_at_utc': 'UTC write timestamp for the persisted regime row.',
     },
@@ -185,7 +185,7 @@ class CryptoSignalRepository:
                     asset_symbol TEXT NOT NULL,
                     venue_scope TEXT NOT NULL,
                     instrument_scope TEXT NOT NULL,
-                    cadence TEXT NOT NULL,
+                    interval TEXT NOT NULL,
                     source_payload_version INTEGER NOT NULL,
                     created_at_utc TEXT NOT NULL,
                     UNIQUE (
@@ -195,7 +195,7 @@ class CryptoSignalRepository:
                         asset_symbol,
                         venue_scope,
                         instrument_scope,
-                        cadence
+                        interval
                     )
                 )
                 """
@@ -350,7 +350,7 @@ class CryptoSignalRepository:
                     asset_symbol,
                     venue_scope,
                     instrument_scope,
-                    cadence,
+                    interval,
                     source_payload_version,
                     created_at_utc
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -361,7 +361,7 @@ class CryptoSignalRepository:
                     asset_symbol,
                     venue_scope,
                     instrument_scope,
-                    cadence
+                    interval
                 ) DO UPDATE SET
                     source_payload_version=excluded.source_payload_version,
                     created_at_utc=excluded.created_at_utc
@@ -373,7 +373,7 @@ class CryptoSignalRepository:
                     snapshot.asset_symbol,
                     snapshot.venue_scope,
                     snapshot.instrument_scope,
-                    snapshot.cadence,
+                    snapshot.interval,
                     snapshot.source_payload_version,
                     self._format_timestamp(created_at_utc),
                 ),
@@ -388,7 +388,7 @@ class CryptoSignalRepository:
                   AND asset_symbol = ?
                   AND venue_scope = ?
                   AND instrument_scope = ?
-                  AND cadence = ?
+                  AND interval = ?
                 """,
                 (
                     self._format_timestamp(snapshot.observed_at_utc),
@@ -397,7 +397,7 @@ class CryptoSignalRepository:
                     snapshot.asset_symbol,
                     snapshot.venue_scope,
                     snapshot.instrument_scope,
-                    snapshot.cadence,
+                    snapshot.interval,
                 ),
             ).fetchone()
             snapshot_id = int(snapshot_row['snapshot_id'])
@@ -445,7 +445,7 @@ class CryptoSignalRepository:
         provider: str | None = None,
         venue_scope: str | None = None,
         instrument_scope: str | None = None,
-        cadence: str | None = None,
+        interval: str | None = None,
     ) -> list[CryptoSignalMarketRegimeMetric]:
         if not metric_names or not Path(self.db_path).exists():
             return []
@@ -466,9 +466,9 @@ class CryptoSignalRepository:
         if instrument_scope is not None:
             scope_filters.append('snapshot.instrument_scope = ?')
             params.append(instrument_scope)
-        if cadence is not None:
-            scope_filters.append('snapshot.cadence = ?')
-            params.append(cadence)
+        if interval is not None:
+            scope_filters.append('snapshot.interval = ?')
+            params.append(interval)
         params.extend(metric_names)
         scope_filter_sql = (
             ''
@@ -486,7 +486,7 @@ class CryptoSignalRepository:
                         snapshot.asset_symbol,
                         snapshot.venue_scope,
                         snapshot.instrument_scope,
-                        snapshot.cadence
+                        snapshot.interval
                     FROM crypto_signal_market_regime_metrics AS metric
                     INNER JOIN crypto_signal_market_regime_snapshots AS snapshot
                       ON snapshot.snapshot_id = metric.snapshot_id
@@ -784,7 +784,7 @@ class CryptoSignalRepository:
             instrument_scope=(
                 row['instrument_scope'] if 'instrument_scope' in row.keys() else None
             ),
-            cadence=row['cadence'] if 'cadence' in row.keys() else None,
+            interval=row['interval'] if 'interval' in row.keys() else None,
             created_at_utc=self._parse_timestamp(row['created_at_utc']),
         )
 
@@ -799,7 +799,7 @@ class CryptoSignalRepository:
                 row['asset_symbol'],
                 row['venue_scope'],
                 row['instrument_scope'],
-                row['cadence'],
+                row['interval'],
                 row['metric_name'],
                 row['source_timestamp_utc'],
             )

--- a/src/service/crypto_signal/repository.py
+++ b/src/service/crypto_signal/repository.py
@@ -8,6 +8,8 @@ from src.config import config
 from src.runtime.runtime_mode import DEFAULT_RUNTIME_MODE, RuntimeMode
 from src.service.crypto_signal.models import (
     CryptoSignalCoinSnapshot,
+    CryptoSignalMarketRegimeMetric,
+    CryptoSignalMarketRegimeSnapshot,
     CryptoSignalRunRecord,
     CryptoSignalSnapshot,
 )
@@ -60,6 +62,26 @@ SCHEMA_DOCS = {
         'is_watchlist': '1 when the configured watchlist included this coin for the run.',
         'context_tags_json': 'Stable JSON array describing how the coin entered the snapshot.',
         'created_at_utc': 'UTC write timestamp for the persisted coin row.',
+    },
+    'crypto_signal_market_regime_snapshots': {
+        'snapshot_id': 'Synthetic market-regime snapshot identifier.',
+        'observed_at_utc': 'UTC observation timestamp for the regime collector run.',
+        'runtime_mode': 'Runtime mode label used when the regime snapshot was captured.',
+        'provider': 'Provider name, such as coinalyze or binance.',
+        'asset_symbol': 'Benchmark asset symbol, initially BTC.',
+        'venue_scope': 'Exchange or aggregate venue scope.',
+        'instrument_scope': 'Provider instrument scope or symbol.',
+        'cadence': 'Sampling cadence for the stored metrics.',
+        'source_payload_version': 'Provider payload mapping version.',
+        'created_at_utc': 'UTC write timestamp for the persisted regime row.',
+    },
+    'crypto_signal_market_regime_metrics': {
+        'snapshot_id': 'Foreign key to crypto_signal_market_regime_snapshots.',
+        'metric_name': 'Stable metric name, such as open_interest_usd or funding_rate.',
+        'metric_value': 'Numeric metric value when provider data is available.',
+        'unit': 'Metric unit, such as usd or percent.',
+        'source_timestamp_utc': 'Provider source timestamp for the metric value.',
+        'created_at_utc': 'UTC write timestamp for the persisted metric row.',
     },
 }
 
@@ -151,6 +173,52 @@ class CryptoSignalRepository:
                 """
                 CREATE INDEX IF NOT EXISTS idx_crypto_signal_coin_snapshots_symbol_run_id
                 ON crypto_signal_coin_snapshots (symbol, run_id)
+                """
+            )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS crypto_signal_market_regime_snapshots (
+                    snapshot_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    observed_at_utc TEXT NOT NULL,
+                    runtime_mode TEXT NOT NULL,
+                    provider TEXT NOT NULL,
+                    asset_symbol TEXT NOT NULL,
+                    venue_scope TEXT NOT NULL,
+                    instrument_scope TEXT NOT NULL,
+                    cadence TEXT NOT NULL,
+                    source_payload_version INTEGER NOT NULL,
+                    created_at_utc TEXT NOT NULL,
+                    UNIQUE (
+                        observed_at_utc,
+                        runtime_mode,
+                        provider,
+                        asset_symbol,
+                        venue_scope,
+                        instrument_scope,
+                        cadence
+                    )
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS crypto_signal_market_regime_metrics (
+                    snapshot_id INTEGER NOT NULL,
+                    metric_name TEXT NOT NULL,
+                    metric_value REAL NULL,
+                    unit TEXT NOT NULL,
+                    source_timestamp_utc TEXT NOT NULL,
+                    created_at_utc TEXT NOT NULL,
+                    PRIMARY KEY (snapshot_id, metric_name, source_timestamp_utc),
+                    FOREIGN KEY (snapshot_id)
+                        REFERENCES crypto_signal_market_regime_snapshots(snapshot_id)
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_crypto_signal_market_regime_metrics_name_time
+                ON crypto_signal_market_regime_metrics (metric_name, source_timestamp_utc)
                 """
             )
             # Current phase-1 reads filter one run via the (run_id, coin_id)
@@ -264,6 +332,182 @@ class CryptoSignalRepository:
             coin.run_id = run_id
             coin.created_at_utc = created_at_utc
         return snapshot
+
+    def save_market_regime_snapshot(
+        self,
+        snapshot: CryptoSignalMarketRegimeSnapshot,
+    ) -> CryptoSignalMarketRegimeSnapshot:
+        self.init_schema()
+        created_at_utc = self._utcnow()
+
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO crypto_signal_market_regime_snapshots (
+                    observed_at_utc,
+                    runtime_mode,
+                    provider,
+                    asset_symbol,
+                    venue_scope,
+                    instrument_scope,
+                    cadence,
+                    source_payload_version,
+                    created_at_utc
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (
+                    observed_at_utc,
+                    runtime_mode,
+                    provider,
+                    asset_symbol,
+                    venue_scope,
+                    instrument_scope,
+                    cadence
+                ) DO UPDATE SET
+                    source_payload_version=excluded.source_payload_version,
+                    created_at_utc=excluded.created_at_utc
+                """,
+                (
+                    self._format_timestamp(snapshot.observed_at_utc),
+                    snapshot.runtime_mode,
+                    snapshot.provider,
+                    snapshot.asset_symbol,
+                    snapshot.venue_scope,
+                    snapshot.instrument_scope,
+                    snapshot.cadence,
+                    snapshot.source_payload_version,
+                    self._format_timestamp(created_at_utc),
+                ),
+            )
+            snapshot_row = connection.execute(
+                """
+                SELECT snapshot_id
+                FROM crypto_signal_market_regime_snapshots
+                WHERE observed_at_utc = ?
+                  AND runtime_mode = ?
+                  AND provider = ?
+                  AND asset_symbol = ?
+                  AND venue_scope = ?
+                  AND instrument_scope = ?
+                  AND cadence = ?
+                """,
+                (
+                    self._format_timestamp(snapshot.observed_at_utc),
+                    snapshot.runtime_mode,
+                    snapshot.provider,
+                    snapshot.asset_symbol,
+                    snapshot.venue_scope,
+                    snapshot.instrument_scope,
+                    snapshot.cadence,
+                ),
+            ).fetchone()
+            snapshot_id = int(snapshot_row['snapshot_id'])
+            connection.executemany(
+                """
+                INSERT INTO crypto_signal_market_regime_metrics (
+                    snapshot_id,
+                    metric_name,
+                    metric_value,
+                    unit,
+                    source_timestamp_utc,
+                    created_at_utc
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT (snapshot_id, metric_name, source_timestamp_utc)
+                DO UPDATE SET
+                    metric_value=excluded.metric_value,
+                    unit=excluded.unit,
+                    created_at_utc=excluded.created_at_utc
+                """,
+                [
+                    self._serialize_market_regime_metric(
+                        metric=metric,
+                        snapshot_id=snapshot_id,
+                        created_at_utc=created_at_utc,
+                    )
+                    for metric in snapshot.metrics
+                ],
+            )
+            connection.commit()
+
+        snapshot.snapshot_id = snapshot_id
+        snapshot.created_at_utc = created_at_utc
+        for metric in snapshot.metrics:
+            metric.snapshot_id = snapshot_id
+            metric.created_at_utc = created_at_utc
+        return snapshot
+
+    def get_market_regime_metrics(
+        self,
+        runtime_mode: str,
+        start_timestamp_utc: datetime.datetime,
+        end_timestamp_utc: datetime.datetime,
+        metric_names: list[str],
+        asset_symbol: str = 'BTC',
+        provider: str | None = None,
+        venue_scope: str | None = None,
+        instrument_scope: str | None = None,
+        cadence: str | None = None,
+    ) -> list[CryptoSignalMarketRegimeMetric]:
+        if not metric_names or not Path(self.db_path).exists():
+            return []
+        placeholders = ','.join('?' for _ in metric_names)
+        scope_filters = []
+        params = [
+            runtime_mode,
+            asset_symbol,
+            self._format_timestamp(start_timestamp_utc),
+            self._format_timestamp(end_timestamp_utc),
+        ]
+        if provider is not None:
+            scope_filters.append('snapshot.provider = ?')
+            params.append(provider)
+        if venue_scope is not None:
+            scope_filters.append('snapshot.venue_scope = ?')
+            params.append(venue_scope)
+        if instrument_scope is not None:
+            scope_filters.append('snapshot.instrument_scope = ?')
+            params.append(instrument_scope)
+        if cadence is not None:
+            scope_filters.append('snapshot.cadence = ?')
+            params.append(cadence)
+        params.extend(metric_names)
+        scope_filter_sql = (
+            ''
+            if not scope_filters
+            else ' AND ' + ' AND '.join(scope_filters)
+        )
+        with self._connect() as connection:
+            try:
+                rows = connection.execute(
+                    f"""
+                    SELECT
+                        metric.*,
+                        snapshot.observed_at_utc AS snapshot_observed_at_utc,
+                        snapshot.provider,
+                        snapshot.asset_symbol,
+                        snapshot.venue_scope,
+                        snapshot.instrument_scope,
+                        snapshot.cadence
+                    FROM crypto_signal_market_regime_metrics AS metric
+                    INNER JOIN crypto_signal_market_regime_snapshots AS snapshot
+                      ON snapshot.snapshot_id = metric.snapshot_id
+                    WHERE snapshot.runtime_mode = ?
+                      AND snapshot.asset_symbol = ?
+                      AND metric.source_timestamp_utc >= ?
+                      AND metric.source_timestamp_utc <= ?
+                      {scope_filter_sql}
+                      AND metric.metric_name IN ({placeholders})
+                    ORDER BY metric.source_timestamp_utc ASC, metric.metric_name ASC
+                    """,
+                    params,
+                ).fetchall()
+            except sqlite3.OperationalError as error:
+                if 'no such table' in str(error):
+                    return []
+                raise
+        return [
+            self._build_market_regime_metric(row)
+            for row in self._dedupe_market_regime_metric_rows(rows)
+        ]
 
     def save_or_merge_snapshot(
         self,
@@ -509,6 +753,67 @@ class CryptoSignalRepository:
             self._format_timestamp(created_at_utc),
         )
 
+    def _serialize_market_regime_metric(
+        self,
+        metric: CryptoSignalMarketRegimeMetric,
+        snapshot_id: int,
+        created_at_utc: datetime.datetime,
+    ) -> tuple:
+        return (
+            snapshot_id,
+            metric.metric_name,
+            metric.metric_value,
+            metric.unit,
+            self._format_timestamp(metric.source_timestamp_utc),
+            self._format_timestamp(created_at_utc),
+        )
+
+    def _build_market_regime_metric(
+        self,
+        row: sqlite3.Row,
+    ) -> CryptoSignalMarketRegimeMetric:
+        return CryptoSignalMarketRegimeMetric(
+            snapshot_id=row['snapshot_id'],
+            metric_name=row['metric_name'],
+            metric_value=row['metric_value'],
+            unit=row['unit'],
+            source_timestamp_utc=self._parse_timestamp(row['source_timestamp_utc']),
+            provider=row['provider'] if 'provider' in row.keys() else None,
+            asset_symbol=row['asset_symbol'] if 'asset_symbol' in row.keys() else None,
+            venue_scope=row['venue_scope'] if 'venue_scope' in row.keys() else None,
+            instrument_scope=(
+                row['instrument_scope'] if 'instrument_scope' in row.keys() else None
+            ),
+            cadence=row['cadence'] if 'cadence' in row.keys() else None,
+            created_at_utc=self._parse_timestamp(row['created_at_utc']),
+        )
+
+    @staticmethod
+    def _dedupe_market_regime_metric_rows(
+        rows: list[sqlite3.Row],
+    ) -> list[sqlite3.Row]:
+        latest_by_fact_key: dict[tuple, sqlite3.Row] = {}
+        for row in rows:
+            fact_key = (
+                row['provider'],
+                row['asset_symbol'],
+                row['venue_scope'],
+                row['instrument_scope'],
+                row['cadence'],
+                row['metric_name'],
+                row['source_timestamp_utc'],
+            )
+            existing = latest_by_fact_key.get(fact_key)
+            if existing is None or (
+                _market_regime_row_version_key(row)
+                > _market_regime_row_version_key(existing)
+            ):
+                latest_by_fact_key[fact_key] = row
+        return sorted(
+            latest_by_fact_key.values(),
+            key=lambda row: (row['source_timestamp_utc'], row['metric_name']),
+        )
+
     def _connect(self) -> sqlite3.Connection:
         connection = sqlite3.connect(self.db_path)
         connection.row_factory = sqlite3.Row
@@ -532,6 +837,14 @@ class CryptoSignalRepository:
     @staticmethod
     def _parse_timestamp(value: str) -> datetime.datetime:
         return datetime.datetime.fromisoformat(value.replace('Z', '+00:00'))
+
+
+def _market_regime_row_version_key(row: sqlite3.Row) -> tuple[str, str, int]:
+    return (
+        row['snapshot_observed_at_utc'],
+        row['created_at_utc'],
+        int(row['snapshot_id']),
+    )
 
 
 def iter_snapshot_coin_ids(

--- a/src/service/crypto_signal/repository.py
+++ b/src/service/crypto_signal/repository.py
@@ -794,6 +794,9 @@ class CryptoSignalRepository:
     ) -> list[sqlite3.Row]:
         latest_by_fact_key: dict[tuple, sqlite3.Row] = {}
         for row in rows:
+            # Scheduled collections can re-fetch overlapping historical points
+            # under later snapshots. Read-side summaries use the latest stored
+            # fact for each provider/scope/metric/source timestamp.
             fact_key = (
                 row['provider'],
                 row['asset_symbol'],

--- a/src/service/crypto_signal/scorer.py
+++ b/src/service/crypto_signal/scorer.py
@@ -6,6 +6,7 @@ from src.service.crypto_signal.models import (
     CryptoSignalCandidate,
     CryptoSignalCoinSnapshot,
     CryptoSignalDigestView,
+    CryptoSignalMarketRegimeSummary,
     CryptoSignalSnapshot,
 )
 
@@ -58,6 +59,7 @@ def build_digest_view(
     limit: int = 3,
     min_dynamic_price_usd: float = 1.0,
     min_dynamic_volume_24h: float = 50_000_000.0,
+    market_regime_summary: CryptoSignalMarketRegimeSummary | None = None,
 ) -> CryptoSignalDigestView:
     tracked_universe_coin_ids = (
         set() if tracked_universe_coin_ids is None else tracked_universe_coin_ids
@@ -135,7 +137,13 @@ def build_digest_view(
         key=lambda candidate: (-abs(candidate.score), candidate.symbol)
     )
 
-    market_regime_label, market_regime_reason = _classify_market_regime(latest_snapshot)
+    if market_regime_summary is None:
+        market_regime_label, market_regime_reason = _classify_market_regime(
+            latest_snapshot
+        )
+    else:
+        market_regime_label = market_regime_summary.label
+        market_regime_reason = market_regime_summary.reason
 
     return CryptoSignalDigestView(
         latest_snapshot=latest_snapshot,

--- a/tests/unit/config/config_test.py
+++ b/tests/unit/config/config_test.py
@@ -270,6 +270,94 @@ def test_crypto_signal_dynamic_candidate_min_volume_24h_defaults(monkeypatch):
     assert config.get_crypto_signal_dynamic_candidate_min_volume_24h() == 50_000_000.0
 
 
+def test_crypto_signal_market_regime_collection_is_disabled_by_default(monkeypatch):
+    monkeypatch.delenv('CRYPTO_SIGNAL_MARKET_REGIME_ENABLED', raising=False)
+
+    assert config.is_crypto_signal_market_regime_enabled() is False
+
+
+def test_crypto_signal_market_regime_coinalyze_symbols_are_explicit(monkeypatch):
+    monkeypatch.delenv('CRYPTO_SIGNAL_MARKET_REGIME_COINALYZE_SYMBOLS', raising=False)
+
+    assert config.get_crypto_signal_market_regime_coinalyze_symbols() == []
+
+    monkeypatch.setenv(
+        'CRYPTO_SIGNAL_MARKET_REGIME_COINALYZE_SYMBOLS',
+        ' BTCUSDT_PERP.A, BTCUSD_PERP.0 ',
+    )
+
+    assert config.get_crypto_signal_market_regime_coinalyze_symbols() == [
+        'BTCUSDT_PERP.A',
+        'BTCUSD_PERP.0',
+    ]
+
+
+def test_crypto_signal_market_regime_coinalyze_symbols_rejects_large_basket(
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        'CRYPTO_SIGNAL_MARKET_REGIME_COINALYZE_SYMBOLS',
+        ','.join(f'BTC-{index}' for index in range(11)),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match='CRYPTO_SIGNAL_MARKET_REGIME_COINALYZE_SYMBOLS supports at most 10 symbols',
+    ):
+        config.get_crypto_signal_market_regime_coinalyze_symbols()
+
+
+def test_crypto_signal_market_regime_provider_defaults_to_coinalyze(monkeypatch):
+    monkeypatch.delenv('CRYPTO_SIGNAL_MARKET_REGIME_PROVIDER', raising=False)
+
+    assert config.get_crypto_signal_market_regime_provider() == 'coinalyze'
+
+
+def test_crypto_signal_market_regime_provider_rejects_unknown(monkeypatch):
+    monkeypatch.setenv('CRYPTO_SIGNAL_MARKET_REGIME_PROVIDER', 'cryptoquant')
+
+    with pytest.raises(
+        RuntimeError,
+        match='CRYPTO_SIGNAL_MARKET_REGIME_PROVIDER must be coinalyze or binance',
+    ):
+        config.get_crypto_signal_market_regime_provider()
+
+
+def test_crypto_signal_market_regime_interval_defaults_to_one_hour(monkeypatch):
+    monkeypatch.delenv('CRYPTO_SIGNAL_MARKET_REGIME_INTERVAL', raising=False)
+
+    assert config.get_crypto_signal_market_regime_interval() == '1hour'
+
+
+def test_crypto_signal_market_regime_backfill_days_defaults_to_30(monkeypatch):
+    monkeypatch.delenv('CRYPTO_SIGNAL_MARKET_REGIME_BACKFILL_DAYS', raising=False)
+    monkeypatch.delenv('CRYPTO_SIGNAL_MARKET_REGIME_INTERVAL', raising=False)
+
+    assert config.get_crypto_signal_market_regime_backfill_days() == 30
+
+
+def test_crypto_signal_market_regime_backfill_days_enforces_intraday_retention(
+    monkeypatch,
+):
+    monkeypatch.setenv('CRYPTO_SIGNAL_MARKET_REGIME_INTERVAL', '15min')
+    monkeypatch.setenv('CRYPTO_SIGNAL_MARKET_REGIME_BACKFILL_DAYS', '30')
+
+    with pytest.raises(
+        RuntimeError,
+        match='exceeds Coinalyze intraday retention for 15min',
+    ):
+        config.get_crypto_signal_market_regime_backfill_days()
+
+
+def test_crypto_signal_market_regime_backfill_days_allows_daily_history(
+    monkeypatch,
+):
+    monkeypatch.setenv('CRYPTO_SIGNAL_MARKET_REGIME_INTERVAL', 'daily')
+    monkeypatch.setenv('CRYPTO_SIGNAL_MARKET_REGIME_BACKFILL_DAYS', '365')
+
+    assert config.get_crypto_signal_market_regime_backfill_days() == 365
+
+
 @pytest.mark.parametrize(
     ('getter_name', 'env_name'),
     [

--- a/tests/unit/data_source/market_data_library_test.py
+++ b/tests/unit/data_source/market_data_library_test.py
@@ -21,6 +21,11 @@ def test_init_market_data_api_passes_cnn_page_load_timeout(monkeypatch):
     )
     monkeypatch.setattr(
         market_data_library.config,
+        'has_coinalyze_api_key',
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        market_data_library.config,
         'get_selenium_stealth',
         lambda: True,
     )
@@ -49,6 +54,72 @@ def test_init_market_data_api_passes_cnn_page_load_timeout(monkeypatch):
             remote_mode=True,
             page_load_timeout_seconds=12,
             server_host='http://localhost:4444',
+        )
+    finally:
+        market_data_library.crypto_api = None
+        market_data_library.tradfi_api = None
+
+
+def test_init_market_data_api_passes_coinalyze_key_only_when_configured(
+    monkeypatch,
+):
+    market_data_library.crypto_api = None
+    market_data_library.tradfi_api = None
+
+    crypto_api = Mock()
+    tradfi_api = Mock()
+    crypto_api_cls = Mock(return_value=crypto_api)
+    tradfi_api_cls = Mock(return_value=tradfi_api)
+
+    monkeypatch.setattr(market_data_library, 'CryptoAPI', crypto_api_cls)
+    monkeypatch.setattr(market_data_library, 'TradFiAPI', tradfi_api_cls)
+    monkeypatch.setattr(
+        market_data_library.config,
+        'get_cryptoquant_api_token',
+        lambda: 'token',
+    )
+    monkeypatch.setattr(
+        market_data_library.config,
+        'has_coinalyze_api_key',
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        market_data_library.config,
+        'get_coinalyze_api_key',
+        lambda: 'coinalyze-key',
+    )
+    monkeypatch.setattr(
+        market_data_library.config,
+        'get_selenium_stealth',
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        market_data_library.config,
+        'get_selenium_remote_mode',
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        market_data_library.config,
+        'get_cnn_page_load_timeout_seconds',
+        lambda: 12,
+    )
+    monkeypatch.setattr(
+        market_data_library.config,
+        'get_selenium_server_host',
+        lambda: None,
+    )
+
+    try:
+        market_data_library.init_market_data_api()
+
+        crypto_api_cls.assert_called_once_with(
+            cryptoquant_api_token='token',
+            coinalyze_api_key='coinalyze-key',
+        )
+        tradfi_api_cls.assert_called_once_with(
+            is_stealth=True,
+            remote_mode=False,
+            page_load_timeout_seconds=12,
         )
     finally:
         market_data_library.crypto_api = None

--- a/tests/unit/job/crypto/crypto_digest_message_sender_test.py
+++ b/tests/unit/job/crypto/crypto_digest_message_sender_test.py
@@ -361,6 +361,64 @@ class TestCryptoDigestMessageSender:
         message_sender.signal_backfill_service.build_snapshots.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_market_regime_collection_is_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv('CRYPTO_SIGNAL_MARKET_REGIME_ENABLED', raising=False)
+
+        message_sender = self.build_message_sender()
+        message_sender.market_regime_collector = AsyncMock()
+
+        await message_sender._persist_market_regime_snapshots(
+            current=datetime.datetime(2026, 4, 29, tzinfo=datetime.timezone.utc)
+        )
+
+        message_sender.market_regime_collector.collect_coinalyze_btc_snapshots.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_market_regime_collection_persists_configured_coinalyze_snapshots(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setenv('CRYPTO_SIGNAL_MARKET_REGIME_ENABLED', 'true')
+        monkeypatch.setenv('CRYPTO_SIGNAL_MARKET_REGIME_PROVIDER', 'coinalyze')
+        monkeypatch.setenv(
+            'CRYPTO_SIGNAL_MARKET_REGIME_COINALYZE_SYMBOLS',
+            'BTCUSDT_PERP.A',
+        )
+
+        snapshot = Mock()
+        message_sender = self.build_message_sender()
+        message_sender.market_regime_collector = AsyncMock()
+        message_sender.market_regime_collector.collect_coinalyze_btc_snapshots = AsyncMock(
+            return_value=[snapshot]
+        )
+
+        await message_sender._persist_market_regime_snapshots(
+            current=datetime.datetime(2026, 4, 29, tzinfo=datetime.timezone.utc)
+        )
+
+        message_sender.market_regime_collector.collect_coinalyze_btc_snapshots.assert_awaited_once()
+        message_sender.signal_repository.save_market_regime_snapshot.assert_called_once_with(
+            snapshot
+        )
+
+    @pytest.mark.asyncio
+    async def test_market_regime_collection_fails_open_for_invalid_provider(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setenv('CRYPTO_SIGNAL_MARKET_REGIME_ENABLED', 'true')
+        monkeypatch.setenv('CRYPTO_SIGNAL_MARKET_REGIME_PROVIDER', 'cryptoquant')
+
+        message_sender = self.build_message_sender()
+        message_sender.market_regime_collector = AsyncMock()
+
+        await message_sender._persist_market_regime_snapshots(
+            current=datetime.datetime(2026, 4, 29, tzinfo=datetime.timezone.utc)
+        )
+
+        message_sender.market_regime_collector.collect_coinalyze_btc_snapshots.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_format_message_adds_threshold_gated_sector_detail(self):
         strongest_sector = copy.deepcopy(self.sector_24h_change[0])
         strongest_sector.sectorId = 'video'

--- a/tests/unit/job/crypto/crypto_digest_message_sender_test.py
+++ b/tests/unit/job/crypto/crypto_digest_message_sender_test.py
@@ -163,22 +163,29 @@ class TestCryptoDigestMessageSender:
             coins=coins,
         )
 
-    def build_message_sender(self):
-        message_sender = object.__new__(CryptoDigestMessageSender)
-        message_sender.cmc_service = AsyncMock()
-        message_sender.sentiment_service = AsyncMock()
-        message_sender.signal_repository = Mock()
-        message_sender.signal_repository.get_coin_observation_counts_since = Mock(
-            return_value={}
-        )
-        message_sender.signal_repository.save_or_merge_snapshot = Mock()
-        message_sender.signal_backfill_service = AsyncMock()
-        message_sender.signal_backfill_service.build_snapshots = AsyncMock(
-            return_value=[]
+    def build_message_sender(
+        self,
+        market_regime_collector=None,
+        market_regime_repository=None,
+    ):
+        cmc_service = AsyncMock()
+        sentiment_service = AsyncMock()
+        signal_repository = Mock()
+        signal_repository.get_coin_observation_counts_since = Mock(return_value={})
+        signal_repository.save_or_merge_snapshot = Mock()
+        signal_backfill_service = AsyncMock()
+        signal_backfill_service.build_snapshots = AsyncMock(return_value=[])
+        message_sender = CryptoDigestMessageSender(
+            runtime_mode=DEFAULT_RUNTIME_MODE,
+            cmc_service=cmc_service,
+            sentiment_service=sentiment_service,
+            signal_repository=signal_repository,
+            signal_backfill_service=signal_backfill_service,
+            market_regime_collector=market_regime_collector,
+            market_regime_repository=market_regime_repository,
         )
         message_sender.tracked_universe_entries = [('BTC', 1), ('ETH', 1027), ('SOL', 5426)]
         message_sender.watchlist_entries = [('BTC', 1), ('ETH', 1027), ('SOL', 5426)]
-        message_sender.runtime_mode = DEFAULT_RUNTIME_MODE
         return message_sender
 
     @pytest.mark.asyncio
@@ -364,14 +371,16 @@ class TestCryptoDigestMessageSender:
     async def test_market_regime_collection_is_disabled_by_default(self, monkeypatch):
         monkeypatch.delenv('CRYPTO_SIGNAL_MARKET_REGIME_ENABLED', raising=False)
 
-        message_sender = self.build_message_sender()
-        message_sender.market_regime_collector = AsyncMock()
+        market_regime_collector = AsyncMock()
+        message_sender = self.build_message_sender(
+            market_regime_collector=market_regime_collector
+        )
 
         await message_sender._persist_market_regime_snapshots(
             current=datetime.datetime(2026, 4, 29, tzinfo=datetime.timezone.utc)
         )
 
-        message_sender.market_regime_collector.collect_coinalyze_btc_snapshots.assert_not_awaited()
+        market_regime_collector.collect_coinalyze_btc_snapshots.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_market_regime_collection_persists_configured_coinalyze_snapshots(
@@ -386,17 +395,24 @@ class TestCryptoDigestMessageSender:
         )
 
         snapshot = Mock()
-        message_sender = self.build_message_sender()
-        message_sender.market_regime_collector = AsyncMock()
-        message_sender.market_regime_collector.collect_coinalyze_btc_snapshots = AsyncMock(
+        market_regime_collector = AsyncMock()
+        market_regime_collector.collect_coinalyze_btc_snapshots = AsyncMock(
             return_value=[snapshot]
+        )
+        message_sender = CryptoDigestMessageSender(
+            runtime_mode=DEFAULT_RUNTIME_MODE,
+            cmc_service=AsyncMock(),
+            sentiment_service=AsyncMock(),
+            signal_repository=Mock(),
+            signal_backfill_service=AsyncMock(),
+            market_regime_collector=market_regime_collector,
         )
 
         await message_sender._persist_market_regime_snapshots(
             current=datetime.datetime(2026, 4, 29, tzinfo=datetime.timezone.utc)
         )
 
-        message_sender.market_regime_collector.collect_coinalyze_btc_snapshots.assert_awaited_once()
+        market_regime_collector.collect_coinalyze_btc_snapshots.assert_awaited_once()
         message_sender.signal_repository.save_market_regime_snapshot.assert_called_once_with(
             snapshot
         )
@@ -409,14 +425,16 @@ class TestCryptoDigestMessageSender:
         monkeypatch.setenv('CRYPTO_SIGNAL_MARKET_REGIME_ENABLED', 'true')
         monkeypatch.setenv('CRYPTO_SIGNAL_MARKET_REGIME_PROVIDER', 'cryptoquant')
 
-        message_sender = self.build_message_sender()
-        message_sender.market_regime_collector = AsyncMock()
+        market_regime_collector = AsyncMock()
+        message_sender = self.build_message_sender(
+            market_regime_collector=market_regime_collector
+        )
 
         await message_sender._persist_market_regime_snapshots(
             current=datetime.datetime(2026, 4, 29, tzinfo=datetime.timezone.utc)
         )
 
-        message_sender.market_regime_collector.collect_coinalyze_btc_snapshots.assert_not_awaited()
+        market_regime_collector.collect_coinalyze_btc_snapshots.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_format_message_adds_threshold_gated_sector_detail(self):

--- a/tests/unit/job/crypto/crypto_digest_message_sender_test.py
+++ b/tests/unit/job/crypto/crypto_digest_message_sender_test.py
@@ -16,6 +16,10 @@ from src.type.sentiment import FearGreedAverage, FearGreedData, FearGreedResult
 
 
 class TestCryptoDigestMessageSender:
+    @pytest.fixture(autouse=True)
+    def disable_market_regime_collection(self, monkeypatch):
+        monkeypatch.delenv('CRYPTO_SIGNAL_MARKET_REGIME_ENABLED', raising=False)
+
     @staticmethod
     def remove_unknown_fields(my_value, fields: list[dataclasses.Field]):
         field_by_name = {field.name: field for field in fields}
@@ -175,6 +179,11 @@ class TestCryptoDigestMessageSender:
         signal_repository.save_or_merge_snapshot = Mock()
         signal_backfill_service = AsyncMock()
         signal_backfill_service.build_snapshots = AsyncMock(return_value=[])
+        if market_regime_collector is None:
+            market_regime_collector = AsyncMock()
+            market_regime_collector.collect_coinalyze_btc_snapshots = AsyncMock(
+                return_value=[]
+            )
         message_sender = CryptoDigestMessageSender(
             runtime_mode=DEFAULT_RUNTIME_MODE,
             cmc_service=cmc_service,

--- a/tests/unit/job/crypto/crypto_digest_message_sender_test.py
+++ b/tests/unit/job/crypto/crypto_digest_message_sender_test.py
@@ -427,6 +427,66 @@ class TestCryptoDigestMessageSender:
         )
 
     @pytest.mark.asyncio
+    async def test_market_regime_collection_fails_open_when_collector_fails(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setenv('CRYPTO_SIGNAL_MARKET_REGIME_ENABLED', 'true')
+        monkeypatch.setenv('CRYPTO_SIGNAL_MARKET_REGIME_PROVIDER', 'coinalyze')
+        monkeypatch.setenv(
+            'CRYPTO_SIGNAL_MARKET_REGIME_COINALYZE_SYMBOLS',
+            'BTCUSDT_PERP.A',
+        )
+
+        market_regime_collector = AsyncMock()
+        market_regime_collector.collect_coinalyze_btc_snapshots = AsyncMock(
+            side_effect=RuntimeError('coinalyze unavailable')
+        )
+        message_sender = self.build_message_sender(
+            market_regime_collector=market_regime_collector
+        )
+
+        await message_sender._persist_market_regime_snapshots(
+            current=datetime.datetime(2026, 4, 29, tzinfo=datetime.timezone.utc)
+        )
+
+        market_regime_collector.collect_coinalyze_btc_snapshots.assert_awaited_once()
+        message_sender.signal_repository.save_market_regime_snapshot.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_market_regime_collection_fails_open_when_snapshot_save_fails(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setenv('CRYPTO_SIGNAL_MARKET_REGIME_ENABLED', 'true')
+        monkeypatch.setenv('CRYPTO_SIGNAL_MARKET_REGIME_PROVIDER', 'coinalyze')
+        monkeypatch.setenv(
+            'CRYPTO_SIGNAL_MARKET_REGIME_COINALYZE_SYMBOLS',
+            'BTCUSDT_PERP.A',
+        )
+
+        snapshot = Mock()
+        market_regime_collector = AsyncMock()
+        market_regime_collector.collect_coinalyze_btc_snapshots = AsyncMock(
+            return_value=[snapshot]
+        )
+        message_sender = self.build_message_sender(
+            market_regime_collector=market_regime_collector
+        )
+        message_sender.signal_repository.save_market_regime_snapshot.side_effect = (
+            RuntimeError('sqlite unavailable')
+        )
+
+        await message_sender._persist_market_regime_snapshots(
+            current=datetime.datetime(2026, 4, 29, tzinfo=datetime.timezone.utc)
+        )
+
+        market_regime_collector.collect_coinalyze_btc_snapshots.assert_awaited_once()
+        message_sender.signal_repository.save_market_regime_snapshot.assert_called_once_with(
+            snapshot
+        )
+
+    @pytest.mark.asyncio
     async def test_market_regime_collection_fails_open_for_invalid_provider(
         self,
         monkeypatch,

--- a/tests/unit/job/crypto/crypto_signal_digest_message_sender_test.py
+++ b/tests/unit/job/crypto/crypto_signal_digest_message_sender_test.py
@@ -6,6 +6,11 @@ from src.job.crypto.crypto_signal_digest_message_sender import (
     CryptoSignalDigestMessageSender,
 )
 from src.runtime.runtime_mode import DEFAULT_RUNTIME_MODE
+from src.service.crypto_signal.market_regime_collector import (
+    AGGREGATE_INSTRUMENT_SCOPE,
+    AGGREGATE_VENUE_SCOPE,
+    COINALYZE_PROVIDER,
+)
 from src.service.crypto_signal.models import (
     CryptoSignalCoinSnapshot,
     CryptoSignalMarketRegimeMetric,
@@ -160,7 +165,12 @@ async def test_format_message_uses_stored_coinalyze_market_regime_summary(
     )
 
     class _RepositoryWithRegime(_FakeRepository):
-        def get_market_regime_metrics(self, **_kwargs):
+        def __init__(self, latest_snapshot):
+            super().__init__(latest_snapshot)
+            self.market_regime_kwargs = None
+
+        def get_market_regime_metrics(self, **kwargs):
+            self.market_regime_kwargs = kwargs
             return [
                 CryptoSignalMarketRegimeMetric(
                     metric_name='open_interest_usd',
@@ -203,7 +213,8 @@ async def test_format_message_uses_stored_coinalyze_market_regime_summary(
                 ),
             ]
 
-    sender = _build_sender(_RepositoryWithRegime(latest_snapshot))
+    repository = _RepositoryWithRegime(latest_snapshot)
+    sender = _build_sender(repository)
 
     monkeypatch.setattr(
         'src.job.crypto.crypto_signal_digest_message_sender.get_current_datetime',
@@ -214,6 +225,14 @@ async def test_format_message_uses_stored_coinalyze_market_regime_summary(
 
     assert 'Leverage building' in messages[0]
     assert 'OI \\+8\\.0%' in messages[0]
+    assert repository.market_regime_kwargs is not None
+    assert repository.market_regime_kwargs['provider'] == COINALYZE_PROVIDER
+    assert repository.market_regime_kwargs['venue_scope'] == AGGREGATE_VENUE_SCOPE
+    assert (
+        repository.market_regime_kwargs['instrument_scope']
+        == AGGREGATE_INSTRUMENT_SCOPE
+    )
+    assert repository.market_regime_kwargs['interval'] == '1hour'
 
 
 @pytest.mark.asyncio

--- a/tests/unit/job/crypto/crypto_signal_digest_message_sender_test.py
+++ b/tests/unit/job/crypto/crypto_signal_digest_message_sender_test.py
@@ -97,6 +97,28 @@ class _FakeRepository:
         return []
 
 
+def _build_sender(
+    repository,
+    *,
+    watchlist_entries=None,
+    tracked_universe_entries=None,
+) -> CryptoSignalDigestMessageSender:
+    return CryptoSignalDigestMessageSender(
+        runtime_mode=DEFAULT_RUNTIME_MODE,
+        signal_repository=repository,
+        watchlist_entries=(
+            [('BTC', 1), ('SOL', 5426)]
+            if watchlist_entries is None
+            else watchlist_entries
+        ),
+        tracked_universe_entries=(
+            [('BTC', 1), ('SOL', 5426)]
+            if tracked_universe_entries is None
+            else tracked_universe_entries
+        ),
+    )
+
+
 @pytest.mark.asyncio
 async def test_format_message_builds_operator_digest(monkeypatch):
     earlier_snapshot = _build_snapshot(
@@ -107,13 +129,12 @@ async def test_format_message_builds_operator_digest(monkeypatch):
         datetime.datetime(2026, 4, 21, 8, 45, tzinfo=datetime.timezone.utc)
     )
 
-    sender = object.__new__(CryptoSignalDigestMessageSender)
-    sender.signal_repository = _FakeRepository(
-        latest_snapshot,
-        history=[earlier_snapshot, latest_snapshot],
+    sender = _build_sender(
+        _FakeRepository(
+            latest_snapshot,
+            history=[earlier_snapshot, latest_snapshot],
+        ),
     )
-    sender.watchlist_entries = [('BTC', 1), ('SOL', 5426)]
-    sender.runtime_mode = DEFAULT_RUNTIME_MODE
 
     monkeypatch.setattr(
         'src.job.crypto.crypto_signal_digest_message_sender.get_current_datetime',
@@ -182,11 +203,7 @@ async def test_format_message_uses_stored_coinalyze_market_regime_summary(
                 ),
             ]
 
-    sender = object.__new__(CryptoSignalDigestMessageSender)
-    sender.signal_repository = _RepositoryWithRegime(latest_snapshot)
-    sender.watchlist_entries = [('BTC', 1), ('SOL', 5426)]
-    sender.tracked_universe_entries = [('BTC', 1), ('SOL', 5426)]
-    sender.runtime_mode = DEFAULT_RUNTIME_MODE
+    sender = _build_sender(_RepositoryWithRegime(latest_snapshot))
 
     monkeypatch.setattr(
         'src.job.crypto.crypto_signal_digest_message_sender.get_current_datetime',
@@ -205,10 +222,7 @@ async def test_format_message_skips_stale_snapshot(monkeypatch):
         datetime.datetime(2026, 4, 20, 8, 45, tzinfo=datetime.timezone.utc)
     )
 
-    sender = object.__new__(CryptoSignalDigestMessageSender)
-    sender.signal_repository = _FakeRepository(latest_snapshot)
-    sender.watchlist_entries = [('BTC', 1), ('SOL', 5426)]
-    sender.runtime_mode = DEFAULT_RUNTIME_MODE
+    sender = _build_sender(_FakeRepository(latest_snapshot))
 
     monkeypatch.setattr(
         'src.job.crypto.crypto_signal_digest_message_sender.get_current_datetime',

--- a/tests/unit/job/crypto/crypto_signal_digest_message_sender_test.py
+++ b/tests/unit/job/crypto/crypto_signal_digest_message_sender_test.py
@@ -8,6 +8,7 @@ from src.job.crypto.crypto_signal_digest_message_sender import (
 from src.runtime.runtime_mode import DEFAULT_RUNTIME_MODE
 from src.service.crypto_signal.models import (
     CryptoSignalCoinSnapshot,
+    CryptoSignalMarketRegimeMetric,
     CryptoSignalRunRecord,
     CryptoSignalSnapshot,
 )
@@ -92,6 +93,9 @@ class _FakeRepository:
     def get_snapshots_since(self, _start):
         return self.history
 
+    def get_market_regime_metrics(self, **_kwargs):
+        return []
+
 
 @pytest.mark.asyncio
 async def test_format_message_builds_operator_digest(monkeypatch):
@@ -124,6 +128,75 @@ async def test_format_message_builds_operator_digest(monkeypatch):
     assert '7d \\+22\\.82%' in messages[0]
     assert '*Watchlist*' in messages[0]
     assert 'Solana' in messages[0]
+
+
+@pytest.mark.asyncio
+async def test_format_message_uses_stored_coinalyze_market_regime_summary(
+    monkeypatch,
+):
+    latest_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 21, 8, 45, tzinfo=datetime.timezone.utc)
+    )
+
+    class _RepositoryWithRegime(_FakeRepository):
+        def get_market_regime_metrics(self, **_kwargs):
+            return [
+                CryptoSignalMarketRegimeMetric(
+                    metric_name='open_interest_usd',
+                    metric_value=100.0,
+                    unit='usd',
+                    source_timestamp_utc=datetime.datetime(
+                        2026,
+                        4,
+                        20,
+                        8,
+                        45,
+                        tzinfo=datetime.timezone.utc,
+                    ),
+                ),
+                CryptoSignalMarketRegimeMetric(
+                    metric_name='open_interest_usd',
+                    metric_value=108.0,
+                    unit='usd',
+                    source_timestamp_utc=datetime.datetime(
+                        2026,
+                        4,
+                        21,
+                        8,
+                        45,
+                        tzinfo=datetime.timezone.utc,
+                    ),
+                ),
+                CryptoSignalMarketRegimeMetric(
+                    metric_name='funding_rate',
+                    metric_value=0.01,
+                    unit='percent',
+                    source_timestamp_utc=datetime.datetime(
+                        2026,
+                        4,
+                        21,
+                        8,
+                        45,
+                        tzinfo=datetime.timezone.utc,
+                    ),
+                ),
+            ]
+
+    sender = object.__new__(CryptoSignalDigestMessageSender)
+    sender.signal_repository = _RepositoryWithRegime(latest_snapshot)
+    sender.watchlist_entries = [('BTC', 1), ('SOL', 5426)]
+    sender.tracked_universe_entries = [('BTC', 1), ('SOL', 5426)]
+    sender.runtime_mode = DEFAULT_RUNTIME_MODE
+
+    monkeypatch.setattr(
+        'src.job.crypto.crypto_signal_digest_message_sender.get_current_datetime',
+        lambda: datetime.datetime(2026, 4, 21, 9, 0, tzinfo=datetime.timezone.utc),
+    )
+
+    messages = await sender.format_message()
+
+    assert 'Leverage building' in messages[0]
+    assert 'OI \\+8\\.0%' in messages[0]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/job/crypto/crypto_signal_report_test.py
+++ b/tests/unit/job/crypto/crypto_signal_report_test.py
@@ -5,8 +5,14 @@ from unittest.mock import AsyncMock
 import pytest
 
 from src.job.crypto import crypto_signal_report
+from src.service.crypto_signal.market_regime_collector import (
+    AGGREGATE_INSTRUMENT_SCOPE,
+    AGGREGATE_VENUE_SCOPE,
+    COINALYZE_PROVIDER,
+)
 from src.service.crypto_signal.models import (
     CryptoSignalCoinSnapshot,
+    CryptoSignalMarketRegimeMetric,
     CryptoSignalRunRecord,
     CryptoSignalSnapshot,
 )
@@ -59,12 +65,57 @@ def _build_snapshot() -> CryptoSignalSnapshot:
 class _FakeRepository:
     def __init__(self, latest_snapshot: CryptoSignalSnapshot):
         self.latest_snapshot = latest_snapshot
+        self.market_regime_kwargs = None
 
     def get_latest_snapshot(self):
         return self.latest_snapshot
 
     def get_snapshots_since(self, _start):
         return [self.latest_snapshot]
+
+    def get_market_regime_metrics(self, **kwargs):
+        self.market_regime_kwargs = kwargs
+        return [
+            CryptoSignalMarketRegimeMetric(
+                metric_name='open_interest_usd',
+                metric_value=100.0,
+                unit='usd',
+                source_timestamp_utc=datetime.datetime(
+                    2026,
+                    4,
+                    21,
+                    8,
+                    45,
+                    tzinfo=datetime.timezone.utc,
+                ),
+            ),
+            CryptoSignalMarketRegimeMetric(
+                metric_name='open_interest_usd',
+                metric_value=108.0,
+                unit='usd',
+                source_timestamp_utc=datetime.datetime(
+                    2026,
+                    4,
+                    22,
+                    8,
+                    45,
+                    tzinfo=datetime.timezone.utc,
+                ),
+            ),
+            CryptoSignalMarketRegimeMetric(
+                metric_name='funding_rate',
+                metric_value=0.01,
+                unit='percent',
+                source_timestamp_utc=datetime.datetime(
+                    2026,
+                    4,
+                    22,
+                    8,
+                    45,
+                    tzinfo=datetime.timezone.utc,
+                ),
+            ),
+        ]
 
 
 @pytest.mark.asyncio
@@ -89,7 +140,7 @@ async def test_main_prints_report_to_stdout_when_send_telegram_disabled(
     monkeypatch.setattr(
         crypto_signal_report,
         'build_crypto_signal_message',
-        lambda _view: '*Crypto trend signal*',
+        lambda view: f'*Crypto trend signal* {view.market_regime_label}',
     )
     monkeypatch.setattr(
         crypto_signal_report.config,
@@ -105,5 +156,13 @@ async def test_main_prints_report_to_stdout_when_send_telegram_disabled(
     await crypto_signal_report.main()
 
     captured = capsys.readouterr()
-    assert captured.out == '*Crypto trend signal*\n'
+    assert captured.out == '*Crypto trend signal* Leverage building\n'
     send_crypto_signal_message.assert_not_awaited()
+    assert fake_repository.market_regime_kwargs is not None
+    assert fake_repository.market_regime_kwargs['provider'] == COINALYZE_PROVIDER
+    assert fake_repository.market_regime_kwargs['venue_scope'] == AGGREGATE_VENUE_SCOPE
+    assert (
+        fake_repository.market_regime_kwargs['instrument_scope']
+        == AGGREGATE_INSTRUMENT_SCOPE
+    )
+    assert fake_repository.market_regime_kwargs['interval'] == '1hour'

--- a/tests/unit/service/coinalyze_test.py
+++ b/tests/unit/service/coinalyze_test.py
@@ -1,0 +1,85 @@
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from market_data_library.core.crypto.coinalyze.type import (
+    CoinalyzeFutureMarket,
+    CoinalyzeHistoryPoint,
+    CoinalyzeHistorySeries,
+)
+
+from src.service.crypto.coinalyze import CoinalyzeService
+
+
+class TestCoinalyzeService:
+    def test_is_configured_returns_false_when_api_key_absent(self) -> None:
+        service = CoinalyzeService(coinalyze_service=None)
+
+        assert service.is_configured() is False
+
+    @pytest.mark.asyncio
+    async def test_get_future_markets_requires_configured_library_service(
+        self,
+    ) -> None:
+        service = CoinalyzeService(coinalyze_service=None)
+
+        with pytest.raises(RuntimeError, match='COINALYZE_API_KEY is not configured'):
+            await service.get_future_markets()
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_library_service(self) -> None:
+        library_service = Mock()
+        library_service.get_future_markets = AsyncMock(
+            return_value=[
+                CoinalyzeFutureMarket(
+                    symbol='BTCUSDT_PERP.A',
+                    exchange='BINANCE',
+                    base_asset='BTC',
+                    quote_asset='USDT',
+                    is_perpetual=True,
+                )
+            ]
+        )
+        library_service.get_open_interest_history = AsyncMock(
+            return_value=[
+                CoinalyzeHistorySeries(
+                    symbol='BTCUSDT_PERP.A',
+                    history=[CoinalyzeHistoryPoint(t=1711929600, c=100.0)],
+                )
+            ]
+        )
+        library_service.get_funding_rate_history = AsyncMock(
+            return_value=[
+                CoinalyzeHistorySeries(
+                    symbol='BTCUSDT_PERP.A',
+                    history=[CoinalyzeHistoryPoint(t=1711929600, c=0.01)],
+                )
+            ]
+        )
+        service = CoinalyzeService(coinalyze_service=library_service)
+
+        markets = await service.get_future_markets()
+        open_interest = await service.get_open_interest_history(
+            symbols=['BTCUSDT_PERP.A'],
+            interval='1hour',
+            from_timestamp_seconds=1711929600,
+            to_timestamp_seconds=1711933200,
+            convert_to_usd=True,
+        )
+        funding = await service.get_funding_rate_history(
+            symbols=['BTCUSDT_PERP.A'],
+            interval='1hour',
+            from_timestamp_seconds=1711929600,
+            to_timestamp_seconds=1711933200,
+        )
+
+        assert service.is_configured() is True
+        assert markets[0].symbol == 'BTCUSDT_PERP.A'
+        assert open_interest[0].history[0].c == 100.0
+        assert funding[0].history[0].c == 0.01
+        library_service.get_open_interest_history.assert_awaited_once_with(
+            symbols=['BTCUSDT_PERP.A'],
+            interval='1hour',
+            from_timestamp_seconds=1711929600,
+            to_timestamp_seconds=1711933200,
+            convert_to_usd=True,
+        )

--- a/tests/unit/service/coinalyze_test.py
+++ b/tests/unit/service/coinalyze_test.py
@@ -12,7 +12,7 @@ from src.service.crypto.coinalyze import CoinalyzeService
 
 class TestCoinalyzeService:
     def test_is_configured_returns_false_when_api_key_absent(self) -> None:
-        service = CoinalyzeService(coinalyze_service=None)
+        service = CoinalyzeService(use_configured_service=False)
 
         assert service.is_configured() is False
 
@@ -20,7 +20,7 @@ class TestCoinalyzeService:
     async def test_get_future_markets_requires_configured_library_service(
         self,
     ) -> None:
-        service = CoinalyzeService(coinalyze_service=None)
+        service = CoinalyzeService(use_configured_service=False)
 
         with pytest.raises(RuntimeError, match='COINALYZE_API_KEY is not configured'):
             await service.get_future_markets()

--- a/tests/unit/service/crypto_signal/market_regime_collector_test.py
+++ b/tests/unit/service/crypto_signal/market_regime_collector_test.py
@@ -1,0 +1,198 @@
+import datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from market_data_library.core.crypto.coinalyze.type import (
+    CoinalyzeFutureMarket,
+    CoinalyzeHistoryPoint,
+    CoinalyzeHistorySeries,
+)
+
+from src.service.crypto_signal.market_regime import (
+    FUNDING_RATE_METRIC,
+    OPEN_INTEREST_METRIC,
+)
+from src.service.crypto_signal.market_regime_collector import (
+    AGGREGATE_INSTRUMENT_SCOPE,
+    AGGREGATE_VENUE_SCOPE,
+    CryptoSignalMarketRegimeCollector,
+)
+
+
+class _FakeCoinalyzeService:
+    def __init__(self) -> None:
+        self.get_future_markets = AsyncMock(
+            return_value=[
+                CoinalyzeFutureMarket(
+                    symbol='BTCUSDT_PERP.A',
+                    exchange='BINANCE',
+                    base_asset='BTC',
+                    quote_asset='USDT',
+                    is_perpetual=True,
+                ),
+                CoinalyzeFutureMarket(
+                    symbol='BTCUSD_PERP.0',
+                    exchange='BITMEX',
+                    base_asset='BTC',
+                    quote_asset='USD',
+                    is_perpetual=True,
+                ),
+                CoinalyzeFutureMarket(
+                    symbol='ETHUSDT_PERP.A',
+                    exchange='BINANCE',
+                    base_asset='ETH',
+                    quote_asset='USDT',
+                    is_perpetual=True,
+                ),
+                CoinalyzeFutureMarket(
+                    symbol='BTCUSDT.1',
+                    exchange='BINANCE',
+                    base_asset='BTC',
+                    quote_asset='USDT',
+                    is_perpetual=False,
+                ),
+            ]
+        )
+        self.get_open_interest_history = AsyncMock(
+            return_value=[
+                CoinalyzeHistorySeries(
+                    symbol='BTCUSDT_PERP.A',
+                    history=[
+                        CoinalyzeHistoryPoint(t=1711929600, c=100.0),
+                        CoinalyzeHistoryPoint(t=1711933200, c=110.0),
+                    ],
+                ),
+                CoinalyzeHistorySeries(
+                    symbol='BTCUSD_PERP.0',
+                    history=[
+                        CoinalyzeHistoryPoint(t=1711929600, c=50.0),
+                        CoinalyzeHistoryPoint(t=1711933200, c=55.0),
+                    ],
+                ),
+            ]
+        )
+        self.get_funding_rate_history = AsyncMock(
+            return_value=[
+                CoinalyzeHistorySeries(
+                    symbol='BTCUSDT_PERP.A',
+                    history=[
+                        CoinalyzeHistoryPoint(t=1711929600, c=0.01),
+                        CoinalyzeHistoryPoint(t=1711933200, c=0.02),
+                    ],
+                ),
+                CoinalyzeHistorySeries(
+                    symbol='BTCUSD_PERP.0',
+                    history=[
+                        CoinalyzeHistoryPoint(t=1711929600, c=0.03),
+                        CoinalyzeHistoryPoint(t=1711933200, c=0.04),
+                    ],
+                ),
+            ]
+        )
+
+
+@pytest.mark.asyncio
+async def test_collect_coinalyze_btc_snapshots_builds_raw_and_aggregate_rows():
+    service = _FakeCoinalyzeService()
+    collector = CryptoSignalMarketRegimeCollector(coinalyze_service=service)
+    observed_at = datetime.datetime(2026, 4, 29, 8, 0, tzinfo=datetime.timezone.utc)
+
+    snapshots = await collector.collect_coinalyze_btc_snapshots(
+        observed_at_utc=observed_at,
+        runtime_mode='test',
+        symbols=['BTCUSDT_PERP.A', 'BTCUSD_PERP.0'],
+        interval='1hour',
+        backfill_days=30,
+    )
+
+    assert [snapshot.instrument_scope for snapshot in snapshots] == [
+        'BTCUSDT_PERP.A',
+        'BTCUSD_PERP.0',
+        AGGREGATE_INSTRUMENT_SCOPE,
+    ]
+    assert snapshots[0].venue_scope == 'binance'
+    assert snapshots[2].venue_scope == AGGREGATE_VENUE_SCOPE
+    aggregate_metrics = snapshots[2].metrics
+    assert [
+        metric.metric_value
+        for metric in aggregate_metrics
+        if metric.metric_name == OPEN_INTEREST_METRIC
+    ] == [150.0, 165.0]
+    assert [
+        metric.metric_value
+        for metric in aggregate_metrics
+        if metric.metric_name == FUNDING_RATE_METRIC
+    ] == [0.02, 0.03]
+
+    service.get_future_markets.assert_awaited_once()
+    service.get_open_interest_history.assert_awaited_once_with(
+        symbols=['BTCUSDT_PERP.A', 'BTCUSD_PERP.0'],
+        interval='1hour',
+        from_timestamp_seconds=int(
+            (observed_at - datetime.timedelta(days=30)).timestamp()
+        ),
+        to_timestamp_seconds=int(observed_at.timestamp()),
+        convert_to_usd=True,
+    )
+    service.get_funding_rate_history.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_collect_coinalyze_btc_snapshots_drops_non_btc_perpetual_symbols():
+    service = _FakeCoinalyzeService()
+    collector = CryptoSignalMarketRegimeCollector(coinalyze_service=service)
+
+    snapshots = await collector.collect_coinalyze_btc_snapshots(
+        observed_at_utc=datetime.datetime(
+            2026,
+            4,
+            29,
+            8,
+            0,
+            tzinfo=datetime.timezone.utc,
+        ),
+        runtime_mode='test',
+        symbols=[
+            'BTCUSDT_PERP.A',
+            'ETHUSDT_PERP.A',
+            'BTCUSDT.1',
+            'MISSING_PERP.A',
+        ],
+        interval='1hour',
+        backfill_days=30,
+    )
+
+    assert [snapshot.instrument_scope for snapshot in snapshots] == [
+        'BTCUSDT_PERP.A',
+        AGGREGATE_INSTRUMENT_SCOPE,
+    ]
+    service.get_open_interest_history.assert_awaited_once()
+    assert service.get_open_interest_history.await_args.kwargs['symbols'] == [
+        'BTCUSDT_PERP.A'
+    ]
+
+
+@pytest.mark.asyncio
+async def test_collect_coinalyze_btc_snapshots_fails_closed_when_metadata_fails():
+    service = _FakeCoinalyzeService()
+    service.get_future_markets.side_effect = RuntimeError('metadata unavailable')
+    collector = CryptoSignalMarketRegimeCollector(coinalyze_service=service)
+
+    snapshots = await collector.collect_coinalyze_btc_snapshots(
+        observed_at_utc=datetime.datetime(
+            2026,
+            4,
+            29,
+            8,
+            0,
+            tzinfo=datetime.timezone.utc,
+        ),
+        runtime_mode='test',
+        symbols=['BTCUSDT_PERP.A'],
+        interval='1hour',
+        backfill_days=30,
+    )
+
+    assert snapshots == []
+    service.get_open_interest_history.assert_not_awaited()
+    service.get_funding_rate_history.assert_not_awaited()

--- a/tests/unit/service/crypto_signal/market_regime_test.py
+++ b/tests/unit/service/crypto_signal/market_regime_test.py
@@ -53,6 +53,32 @@ def test_build_market_regime_summary_handles_insufficient_history():
     assert summary.reason == 'open interest history unavailable'
 
 
+def test_build_market_regime_summary_handles_zero_open_interest_baseline():
+    summary = build_market_regime_summary(
+        [
+            _metric('open_interest_usd', 0.0, '2026-04-20T00:00:00Z'),
+            _metric('open_interest_usd', 100.0, '2026-04-27T00:00:00Z'),
+        ]
+    )
+
+    assert summary.label == 'Insufficient regime history'
+    assert summary.reason == 'open interest baseline unavailable'
+
+
+def test_build_market_regime_summary_detects_mixed_regime():
+    summary = build_market_regime_summary(
+        [
+            _metric('open_interest_usd', 100.0, '2026-04-20T00:00:00Z'),
+            _metric('funding_rate', -0.004, '2026-04-20T00:00:00Z'),
+            _metric('open_interest_usd', 102.0, '2026-04-27T00:00:00Z'),
+            _metric('funding_rate', 0.002, '2026-04-27T00:00:00Z'),
+        ]
+    )
+
+    assert summary.label == 'Mixed'
+    assert summary.reason == 'OI +2.0%, avg funding -0.0010%'
+
+
 def _metric(
     metric_name: str,
     metric_value: float,

--- a/tests/unit/service/crypto_signal/market_regime_test.py
+++ b/tests/unit/service/crypto_signal/market_regime_test.py
@@ -1,0 +1,68 @@
+import datetime
+
+from src.service.crypto_signal.market_regime import build_market_regime_summary
+from src.service.crypto_signal.models import CryptoSignalMarketRegimeMetric
+
+
+def test_build_market_regime_summary_detects_leverage_building():
+    summary = build_market_regime_summary(
+        [
+            _metric('open_interest_usd', 100.0, '2026-04-20T00:00:00Z'),
+            _metric('funding_rate', 0.005, '2026-04-20T00:00:00Z'),
+            _metric('open_interest_usd', 108.0, '2026-04-27T00:00:00Z'),
+            _metric('funding_rate', 0.010, '2026-04-27T00:00:00Z'),
+        ]
+    )
+
+    assert summary.label == 'Leverage building'
+    assert summary.reason == 'OI +8.0%, avg funding +0.0075%'
+
+
+def test_build_market_regime_summary_detects_crowded_long_pressure():
+    summary = build_market_regime_summary(
+        [
+            _metric('open_interest_usd', 100.0, '2026-04-20T00:00:00Z'),
+            _metric('funding_rate', 0.040, '2026-04-20T00:00:00Z'),
+            _metric('open_interest_usd', 101.0, '2026-04-27T00:00:00Z'),
+            _metric('funding_rate', 0.050, '2026-04-27T00:00:00Z'),
+        ]
+    )
+
+    assert summary.label == 'Crowded long pressure'
+    assert summary.reason == 'OI +1.0%, avg funding +0.0450%'
+
+
+def test_build_market_regime_summary_detects_deleveraging():
+    summary = build_market_regime_summary(
+        [
+            _metric('open_interest_usd', 100.0, '2026-04-20T00:00:00Z'),
+            _metric('open_interest_usd', 90.0, '2026-04-27T00:00:00Z'),
+        ]
+    )
+
+    assert summary.label == 'Deleveraging'
+    assert summary.reason == 'OI -10.0%, funding unavailable'
+
+
+def test_build_market_regime_summary_handles_insufficient_history():
+    summary = build_market_regime_summary(
+        [_metric('open_interest_usd', 100.0, '2026-04-20T00:00:00Z')]
+    )
+
+    assert summary.label == 'Insufficient regime history'
+    assert summary.reason == 'open interest history unavailable'
+
+
+def _metric(
+    metric_name: str,
+    metric_value: float,
+    timestamp: str,
+) -> CryptoSignalMarketRegimeMetric:
+    return CryptoSignalMarketRegimeMetric(
+        metric_name=metric_name,
+        metric_value=metric_value,
+        unit='usd' if metric_name == 'open_interest_usd' else 'percent',
+        source_timestamp_utc=datetime.datetime.fromisoformat(
+            timestamp.replace('Z', '+00:00')
+        ),
+    )

--- a/tests/unit/service/crypto_signal/repository_test.py
+++ b/tests/unit/service/crypto_signal/repository_test.py
@@ -3,8 +3,14 @@ import sqlite3
 
 from src.service.crypto_signal.models import (
     CryptoSignalCoinSnapshot,
+    CryptoSignalMarketRegimeMetric,
+    CryptoSignalMarketRegimeSnapshot,
     CryptoSignalRunRecord,
     CryptoSignalSnapshot,
+)
+from src.service.crypto_signal.market_regime import (
+    FUNDING_RATE_METRIC,
+    OPEN_INTEREST_METRIC,
 )
 from src.service.crypto_signal.repository import CryptoSignalRepository
 from src.runtime.runtime_mode import RuntimeMode
@@ -409,3 +415,187 @@ def test_get_coin_observation_counts_since_returns_zero_for_missing_coin(tmp_pat
         1: 0,
         5426: 1,
     }
+
+
+def test_save_market_regime_snapshot_upserts_metrics(tmp_path):
+    repository = CryptoSignalRepository(
+        db_path=str(tmp_path / 'crypto_signal.sqlite3')
+    )
+    observed_at_utc = datetime.datetime(
+        2026,
+        4,
+        27,
+        8,
+        0,
+        tzinfo=datetime.timezone.utc,
+    )
+    source_timestamp_utc = datetime.datetime(
+        2026,
+        4,
+        27,
+        0,
+        0,
+        tzinfo=datetime.timezone.utc,
+    )
+    first_snapshot = CryptoSignalMarketRegimeSnapshot(
+        observed_at_utc=observed_at_utc,
+        runtime_mode='prod',
+        provider='coinalyze',
+        asset_symbol='BTC',
+        venue_scope='aggregate',
+        instrument_scope='btc_perpetual_basket',
+        cadence='1hour',
+        source_payload_version=1,
+        metrics=[
+            CryptoSignalMarketRegimeMetric(
+                metric_name=OPEN_INTEREST_METRIC,
+                metric_value=35_000_000_000,
+                unit='usd',
+                source_timestamp_utc=source_timestamp_utc,
+            ),
+        ],
+    )
+    updated_snapshot = CryptoSignalMarketRegimeSnapshot(
+        observed_at_utc=observed_at_utc,
+        runtime_mode='prod',
+        provider='coinalyze',
+        asset_symbol='BTC',
+        venue_scope='aggregate',
+        instrument_scope='btc_perpetual_basket',
+        cadence='1hour',
+        source_payload_version=1,
+        metrics=[
+            CryptoSignalMarketRegimeMetric(
+                metric_name=OPEN_INTEREST_METRIC,
+                metric_value=36_000_000_000,
+                unit='usd',
+                source_timestamp_utc=source_timestamp_utc,
+            ),
+            CryptoSignalMarketRegimeMetric(
+                metric_name=FUNDING_RATE_METRIC,
+                metric_value=0.0125,
+                unit='percent',
+                source_timestamp_utc=source_timestamp_utc,
+            ),
+        ],
+    )
+    binance_snapshot = CryptoSignalMarketRegimeSnapshot(
+        observed_at_utc=observed_at_utc,
+        runtime_mode='prod',
+        provider='binance',
+        asset_symbol='BTC',
+        venue_scope='binance',
+        instrument_scope='BTCUSDT',
+        cadence='1hour',
+        source_payload_version=1,
+        metrics=[
+            CryptoSignalMarketRegimeMetric(
+                metric_name=OPEN_INTEREST_METRIC,
+                metric_value=40_000_000_000,
+                unit='usd',
+                source_timestamp_utc=source_timestamp_utc,
+            ),
+        ],
+    )
+    later_coinalyze_snapshot = CryptoSignalMarketRegimeSnapshot(
+        observed_at_utc=observed_at_utc + datetime.timedelta(hours=1),
+        runtime_mode='prod',
+        provider='coinalyze',
+        asset_symbol='BTC',
+        venue_scope='aggregate',
+        instrument_scope='btc_perpetual_basket',
+        cadence='1hour',
+        source_payload_version=1,
+        metrics=[
+            CryptoSignalMarketRegimeMetric(
+                metric_name=OPEN_INTEREST_METRIC,
+                metric_value=37_000_000_000,
+                unit='usd',
+                source_timestamp_utc=source_timestamp_utc,
+            ),
+        ],
+    )
+
+    first_saved = repository.save_market_regime_snapshot(first_snapshot)
+    second_saved = repository.save_market_regime_snapshot(updated_snapshot)
+    repository.save_market_regime_snapshot(binance_snapshot)
+    repository.save_market_regime_snapshot(later_coinalyze_snapshot)
+    metrics = repository.get_market_regime_metrics(
+        runtime_mode='prod',
+        start_timestamp_utc=datetime.datetime(
+            2026,
+            4,
+            26,
+            0,
+            0,
+            tzinfo=datetime.timezone.utc,
+        ),
+        end_timestamp_utc=datetime.datetime(
+            2026,
+            4,
+            28,
+            0,
+            0,
+            tzinfo=datetime.timezone.utc,
+        ),
+        metric_names=[OPEN_INTEREST_METRIC, FUNDING_RATE_METRIC],
+        provider='coinalyze',
+        venue_scope='aggregate',
+        instrument_scope='btc_perpetual_basket',
+        cadence='1hour',
+    )
+
+    assert first_saved.snapshot_id == second_saved.snapshot_id
+    assert [(metric.metric_name, metric.metric_value) for metric in metrics] == [
+        (FUNDING_RATE_METRIC, 0.0125),
+        (OPEN_INTEREST_METRIC, 37_000_000_000),
+    ]
+    assert {
+        (
+            metric.provider,
+            metric.asset_symbol,
+            metric.venue_scope,
+            metric.instrument_scope,
+            metric.cadence,
+        )
+        for metric in metrics
+    } == {('coinalyze', 'BTC', 'aggregate', 'btc_perpetual_basket', '1hour')}
+
+    connection = sqlite3.connect(tmp_path / 'crypto_signal.sqlite3')
+    snapshot_count = connection.execute(
+        'SELECT COUNT(*) FROM crypto_signal_market_regime_snapshots'
+    ).fetchone()[0]
+    metric_count = connection.execute(
+        'SELECT COUNT(*) FROM crypto_signal_market_regime_metrics'
+    ).fetchone()[0]
+    connection.close()
+
+    assert snapshot_count == 3
+    assert metric_count == 4
+
+
+def test_get_market_regime_metrics_returns_empty_for_missing_db(tmp_path):
+    repository = CryptoSignalRepository(
+        db_path=str(tmp_path / 'missing_crypto_signal.sqlite3')
+    )
+
+    assert repository.get_market_regime_metrics(
+        runtime_mode='prod',
+        start_timestamp_utc=datetime.datetime(
+            2026,
+            4,
+            26,
+            0,
+            0,
+            tzinfo=datetime.timezone.utc,
+        ),
+        end_timestamp_utc=datetime.datetime(
+            2026,
+            4,
+            28,
+            0,
+            0,
+            tzinfo=datetime.timezone.utc,
+        ),
+        metric_names=[OPEN_INTEREST_METRIC],
+    ) == []

--- a/tests/unit/service/crypto_signal/repository_test.py
+++ b/tests/unit/service/crypto_signal/repository_test.py
@@ -444,7 +444,7 @@ def test_save_market_regime_snapshot_upserts_metrics(tmp_path):
         asset_symbol='BTC',
         venue_scope='aggregate',
         instrument_scope='btc_perpetual_basket',
-        cadence='1hour',
+        interval='1hour',
         source_payload_version=1,
         metrics=[
             CryptoSignalMarketRegimeMetric(
@@ -462,7 +462,7 @@ def test_save_market_regime_snapshot_upserts_metrics(tmp_path):
         asset_symbol='BTC',
         venue_scope='aggregate',
         instrument_scope='btc_perpetual_basket',
-        cadence='1hour',
+        interval='1hour',
         source_payload_version=1,
         metrics=[
             CryptoSignalMarketRegimeMetric(
@@ -486,7 +486,7 @@ def test_save_market_regime_snapshot_upserts_metrics(tmp_path):
         asset_symbol='BTC',
         venue_scope='binance',
         instrument_scope='BTCUSDT',
-        cadence='1hour',
+        interval='1hour',
         source_payload_version=1,
         metrics=[
             CryptoSignalMarketRegimeMetric(
@@ -504,7 +504,7 @@ def test_save_market_regime_snapshot_upserts_metrics(tmp_path):
         asset_symbol='BTC',
         venue_scope='aggregate',
         instrument_scope='btc_perpetual_basket',
-        cadence='1hour',
+        interval='1hour',
         source_payload_version=1,
         metrics=[
             CryptoSignalMarketRegimeMetric(
@@ -542,7 +542,7 @@ def test_save_market_regime_snapshot_upserts_metrics(tmp_path):
         provider='coinalyze',
         venue_scope='aggregate',
         instrument_scope='btc_perpetual_basket',
-        cadence='1hour',
+        interval='1hour',
     )
 
     assert first_saved.snapshot_id == second_saved.snapshot_id
@@ -556,7 +556,7 @@ def test_save_market_regime_snapshot_upserts_metrics(tmp_path):
             metric.asset_symbol,
             metric.venue_scope,
             metric.instrument_scope,
-            metric.cadence,
+            metric.interval,
         )
         for metric in metrics
     } == {('coinalyze', 'BTC', 'aggregate', 'btc_perpetual_basket', '1hour')}

--- a/tests/unit/service/vix_central_test.py
+++ b/tests/unit/service/vix_central_test.py
@@ -519,7 +519,13 @@ class TestVixCentralService:
         )
 
     @pytest.mark.asyncio
-    async def test_get_recent_values_test_mode_includes_unchanged_day_without_losing_alerts(self):
+    @patch("src.service.vix_central.date_util.get_most_recent_non_weekend_or_today")
+    @patch("src.service.vix_central.date_util.get_current_datetime")
+    async def test_get_recent_values_test_mode_includes_unchanged_day_without_losing_alerts(
+        self,
+        get_current_datetime: Mock,
+        get_most_recent_non_weekend_or_today: Mock,
+    ):
         class StubThirdPartyService:
             async def get_current(self):
                 return [['Apr'], None, [47, 50]]
@@ -534,6 +540,9 @@ class TestVixCentralService:
             third_party_service=StubThirdPartyService(),
             number_of_days_to_store=7,
         )
+        current_date = datetime.datetime(2024, 4, 16)
+        get_current_datetime.return_value = current_date
+        get_most_recent_non_weekend_or_today.side_effect = lambda date: date
 
         test_values = await vix_central_service.get_recent_values(
             runtime_mode=RuntimeMode.from_test_mode(True)


### PR DESCRIPTION
## Summary
- add Coinalyze-backed BTC perpetual market-regime collection for crypto signal Phase 2A
- persist raw per-market and aggregate market-regime snapshots/metrics, then surface the aggregate context in private operator output
- keep collection disabled by default and provider-gated; public crypto digest remains fail-open if optional regime collection fails
- pin backend to released `market-data-library` tag `1.6.0`

## Notes
- Coinalyze symbols must resolve through futures metadata as BTC perpetual markets before storage.
- Intraday backfill is capped against Coinalyze retention constraints.
- Current rate limiting is handled in `market-data-library` per `CoinalyzeService` instance; future multi-worker or multi-consumer usage with the same key should add shared limiter state.
- CryptoQuant remains limited to the existing Basic-plan-compatible manual price OHLCV route and is not used for market-regime collection.

## Validation
- `./scripts/show_market_data_library_source.sh` -> `git-installed-package`, imported from `.venv/site-packages`
- `PYTHONPATH="$(pwd)" RUFF_CACHE_DIR=/tmp/ruff-cache-market-data-backend poetry run ruff check ...` for touched backend Python files
- `PYTHONPATH="$(pwd)" poetry run pytest tests/unit` -> 266 passed, 4 existing warnings
- `git diff --check`
- released-package no-send E2E smoke with live Coinalyze calls, temp SQLite DB, no Telegram sends
