### PR TITLE
Add crypto signal calibration cohorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,12 +260,12 @@ PYTHONPATH="$(pwd)" ENV=dev poetry run python src/job/stocks/stocks.py --force_r
 PYTHONPATH="$(pwd)" ENV=dev poetry run python src/job/crypto/crypto.py --force_run=1 --test_mode=1
 ```
 
-### Crypto Signal Phase 1
+### Crypto Signal
 
 The crypto signal feature keeps the public crypto digest unchanged while adding
 SQLite-backed history, deterministic scoring, and a separate operator-only
-signal digest. Phase 1 must stay on private/admin routing; the signal path
-rejects `CRYPTO_TELEGRAM_CHANNEL_ID` as a destination.
+signal digest. Signal output must stay on private/admin routing; the signal
+path rejects `CRYPTO_TELEGRAM_CHANNEL_ID` as a destination.
 
 Data-provider split:
 - `src/job/crypto/crypto.py` fetches live CoinMarketCap, Alternative.me, and
@@ -274,6 +274,9 @@ Data-provider split:
   SQLite history; they do not fetch fresh coin or regime provider data.
 - Run `crypto.py` first when you need fresh test-mode signal rows before
   rendering `crypto_signal_report.py`.
+- Phase 3A calibration, currently branch-local until merge/deploy, also freezes
+  emitted private-signal candidates into cohort rows and lets later scheduled
+  crypto runs resolve `24h`, `3d`, and `7d` outcomes.
 
 ```mermaid
 flowchart LR
@@ -283,7 +286,9 @@ flowchart LR
     coinalyze["Coinalyze<br/>BTC perp OI/funding"]
 
     crypto_job["src/job/crypto/crypto.py<br/>public digest + snapshot writer"]
-    sqlite[("SQLite<br/>crypto signal history")]
+    snapshots[("SQLite<br/>runs + coin snapshots")]
+    regime[("SQLite<br/>market-regime snapshots + metrics")]
+    cohorts[("SQLite<br/>candidate cohorts + outcomes")]
     signal_sender["CryptoSignalDigestMessageSender<br/>private/operator digest"]
     report["crypto_signal_report.py<br/>local report"]
     telegram["Telegram"]
@@ -292,13 +297,30 @@ flowchart LR
     alt --> crypto_job
     coinalyze -. optional market-regime .-> crypto_job
     cq -. manual route only .-> crypto_job
-    crypto_job --> sqlite
+    crypto_job --> snapshots
+    crypto_job -. optional market-regime .-> regime
+    crypto_job -. phase-3A outcome resolution .-> cohorts
     crypto_job --> telegram
-    sqlite --> signal_sender
-    sqlite --> report
+    snapshots --> signal_sender
+    regime --> signal_sender
+    signal_sender -. phase-3A cohort freeze .-> cohorts
+    snapshots --> report
+    regime --> report
     signal_sender --> telegram
     report -. optional private send .-> telegram
 ```
+
+Phase 3A table relationships:
+- `crypto_signal_runs` -> `crypto_signal_coin_snapshots` by `run_id`.
+- `crypto_signal_market_regime_snapshots` ->
+  `crypto_signal_market_regime_metrics` by `snapshot_id`.
+- `crypto_signal_candidate_cohorts` ->
+  `crypto_signal_candidate_outcomes` by `cohort_id`.
+
+Follow-up-only calibration rows are tagged `calibration_follow_up` so collecting
+old emitted candidates for outcome coverage does not create new operator-ranked
+signals. If the same coin reappears through current spotlight or sector context,
+it remains normal dynamic signal evidence.
 
 Render the latest stored signal report without sending Telegram:
 

--- a/README.md
+++ b/README.md
@@ -317,6 +317,23 @@ Phase 3A table relationships:
 - `crypto_signal_candidate_cohorts` ->
   `crypto_signal_candidate_outcomes` by `cohort_id`.
 
+Crypto signal table usage:
+
+| Table | Usage | Notable columns |
+| --- | --- | --- |
+| `crypto_signal_runs` | One row per scheduled crypto signal snapshot run. | `run_timestamp_utc`, `runtime_mode`, `source_name`, sentiment fields, strongest/weakest sector fields |
+| `crypto_signal_coin_snapshots` | Per-coin facts captured for a run; these rows are the input history for operator ranking. | `run_id`, `coin_id`, `symbol`, `price_usd`, `price_change_24h`, `volume_24h`, `volume_change_pct_24h`, `is_watchlist`, `context_tags_json` |
+| `crypto_signal_market_regime_snapshots` | One BTC derivatives regime collection for a provider, venue scope, instrument scope, and interval. | `observed_at_utc`, `runtime_mode`, `provider`, `asset_symbol`, `venue_scope`, `instrument_scope`, `interval` |
+| `crypto_signal_market_regime_metrics` | Metric facts under a regime snapshot, currently BTC perpetual open interest and funding-rate values. | `snapshot_id`, `metric_name`, `metric_value`, `unit`, `source_timestamp_utc` |
+| `crypto_signal_candidate_cohorts` | Frozen private/operator candidates exactly as emitted for calibration; retry renders keep the original row immutable. | `signal_run_timestamp_utc`, `runtime_mode`, `window_label`, `section`, `coin_id`, `baseline_price_usd`, `score`, `reason_tags_json`, `market_regime_label`, `market_regime_reason` |
+| `crypto_signal_candidate_outcomes` | Pending or resolved `24h`, `3d`, and `7d` forward outcomes for each cohort. | `cohort_id`, `outcome_window`, `target_timestamp_utc`, `status`, `candidate_price_usd`, `absolute_return_pct`, `btc_relative_return_pct`, `eth_relative_return_pct`, `missing_reason` |
+
+Candidate cohorts intentionally do not store a direct `run_id` or coin-snapshot
+foreign key. They correlate back to the emitted signal run by
+`signal_run_timestamp_utc + runtime_mode`, and to the emitted coin by `coin_id`.
+That keeps the frozen operator signal independent from later follow-up runs
+while still making the baseline run and coin snapshot joinable for diagnostics.
+
 Follow-up-only calibration rows are tagged `calibration_follow_up` so collecting
 old emitted candidates for outcome coverage does not create new operator-ranked
 signals. If the same coin reappears through current spotlight or sector context,

--- a/src/job/crypto/crypto_digest_message_sender.py
+++ b/src/job/crypto/crypto_digest_message_sender.py
@@ -19,7 +19,12 @@ from src.service.crypto_signal.market_regime_collector import (
     CryptoSignalMarketRegimeCollector,
 )
 from src.service.crypto_signal.backfill import CryptoSignalBackfillService
-from src.service.crypto_signal.repository import CryptoSignalRepository
+from src.service.crypto_signal.models import CALIBRATION_FOLLOW_UP_CONTEXT_TAG
+from src.service.crypto_signal.repository import (
+    BTC_COIN_ID,
+    ETH_COIN_ID,
+    CryptoSignalRepository,
+)
 from src.service.crypto_signal.snapshot_builder import build_snapshot
 from src.type.market_data_type import MarketDataType
 from src.util.date_util import get_current_datetime
@@ -85,7 +90,12 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
             weakest_sector=weakest_sector,
             sector_details=sector_details,
         )
-        tracked_universe_coin_details = await self._load_tracked_universe_coin_details()
+        candidate_follow_up_entries = self._load_candidate_follow_up_entries(
+            current=current
+        )
+        tracked_universe_coin_details = await self._load_tracked_universe_coin_details(
+            extra_entries=candidate_follow_up_entries
+        )
 
         snapshot = self._build_signal_snapshot(
             current=current,
@@ -98,6 +108,11 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
             sector_details=sector_details,
             sector_detail_coin_details=sector_detail_coin_details,
             tracked_universe_coin_details=tracked_universe_coin_details,
+            candidate_follow_up_entries=candidate_follow_up_entries,
+        )
+        self._mark_calibration_follow_up_only_coins(
+            snapshot=snapshot,
+            candidate_follow_up_entries=candidate_follow_up_entries,
         )
         await self._backfill_signal_history(
             current=current,
@@ -111,6 +126,8 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
                 ),
                 market_data_type=MarketDataType.CRYPTO,
             )
+        else:
+            self._resolve_due_candidate_outcomes(current=current)
         await self._persist_market_regime_snapshots(current=current)
 
         digest_message = build_digest_message(
@@ -147,6 +164,7 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
         sector_details,
         sector_detail_coin_details,
         tracked_universe_coin_details,
+        candidate_follow_up_entries,
     ):
         tracked_universe_entries = getattr(
             self,
@@ -172,6 +190,7 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
             tracked_universe_entries=self._get_persisted_universe_entries(
                 tracked_universe_entries=tracked_universe_entries,
                 watchlist_entries=watchlist_entries,
+                extra_entries=candidate_follow_up_entries,
             ),
             tracked_universe_coin_details=tracked_universe_coin_details,
             watchlist_entries=watchlist_entries,
@@ -254,6 +273,51 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
                 should_escape_markdown=True,
             )
         return None
+
+    def _resolve_due_candidate_outcomes(
+        self,
+        current,
+    ) -> None:
+        try:
+            self.signal_repository.resolve_due_candidate_outcomes(
+                runtime_mode=self._runtime_mode_label(),
+                current_timestamp_utc=current.astimezone(datetime.timezone.utc),
+            )
+        except Exception:
+            logger.warning(
+                'Crypto signal candidate outcome resolution failed; continuing digest',
+                exc_info=True,
+            )
+
+    def _mark_calibration_follow_up_only_coins(
+        self,
+        snapshot,
+        candidate_follow_up_entries: List[tuple[str, int]],
+    ) -> None:
+        if len(candidate_follow_up_entries) == 0:
+            return
+        normal_entries = self._get_persisted_universe_entries(
+            tracked_universe_entries=self.tracked_universe_entries,
+            watchlist_entries=self.watchlist_entries,
+        )
+        normal_coin_ids = {coin_id for _symbol, coin_id in normal_entries}
+        follow_up_only_coin_ids = {
+            coin_id
+            for _symbol, coin_id in candidate_follow_up_entries
+            if coin_id not in normal_coin_ids
+        }
+        for coin in snapshot.coins:
+            if coin.coin_id not in follow_up_only_coin_ids:
+                continue
+            if len(coin.context_tags) > 0:
+                continue
+            # Follow-up-only rows are retained for calibration outcome coverage,
+            # but this tag keeps them out of operator ranking unless they become
+            # normally tracked/watchlisted again.
+            coin.context_tags = (
+                *coin.context_tags,
+                CALIBRATION_FOLLOW_UP_CONTEXT_TAG,
+            )
 
     async def _persist_market_regime_snapshots(
         self,
@@ -421,7 +485,10 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
             coin_details[coin_id] = detail
         return coin_details
 
-    async def _load_tracked_universe_coin_details(self) -> Dict[int, cmc_type.CoinDetail]:
+    async def _load_tracked_universe_coin_details(
+        self,
+        extra_entries: List[tuple[str, int]] | None = None,
+    ) -> Dict[int, cmc_type.CoinDetail]:
         tracked_universe_entries = getattr(
             self,
             'tracked_universe_entries',
@@ -438,20 +505,61 @@ class CryptoDigestMessageSender(MessageSenderWrapper):
                 for _symbol, coin_id in self._get_persisted_universe_entries(
                     tracked_universe_entries=tracked_universe_entries,
                     watchlist_entries=watchlist_entries,
+                    extra_entries=extra_entries,
                 )
             ],
             log_context='tracked universe coin enrichment',
+        )
+
+    def _load_candidate_follow_up_entries(
+        self,
+        current,
+    ) -> List[tuple[str, int]]:
+        try:
+            due_entries = (
+                self.signal_repository.get_unresolved_candidate_follow_up_entries(
+                    runtime_mode=self._runtime_mode_label(),
+                    current_timestamp_utc=current.astimezone(datetime.timezone.utc),
+                )
+            )
+        except Exception:
+            logger.warning(
+                'Failed to load crypto signal candidate follow-up entries; continuing digest',
+                exc_info=True,
+            )
+            return []
+        if len(due_entries) == 0:
+            return []
+        # Outcome calibration compares candidates against BTC and ETH, so keep
+        # benchmark prices present even if an operator removes them from the
+        # normal tracked-universe env.
+        return self._merge_coin_entries(
+            [
+                *due_entries,
+                ('BTC', BTC_COIN_ID),
+                ('ETH', ETH_COIN_ID),
+            ]
         )
 
     @staticmethod
     def _get_persisted_universe_entries(
         tracked_universe_entries: List[tuple[str, int]],
         watchlist_entries: List[tuple[str, int]],
+        extra_entries: List[tuple[str, int]] | None = None,
     ) -> List[tuple[str, int]]:
-        merged_entries = {
-            coin_id: (symbol, coin_id)
-            for symbol, coin_id in tracked_universe_entries
-        }
-        for symbol, coin_id in watchlist_entries:
+        return CryptoDigestMessageSender._merge_coin_entries(
+            [
+                *tracked_universe_entries,
+                *watchlist_entries,
+                *(extra_entries or []),
+            ]
+        )
+
+    @staticmethod
+    def _merge_coin_entries(
+        entries: List[tuple[str, int]],
+    ) -> List[tuple[str, int]]:
+        merged_entries = {}
+        for symbol, coin_id in entries:
             merged_entries.setdefault(coin_id, (symbol, coin_id))
         return list(merged_entries.values())

--- a/src/job/crypto/crypto_signal_digest_message_sender.py
+++ b/src/job/crypto/crypto_signal_digest_message_sender.py
@@ -126,7 +126,22 @@ class CryptoSignalDigestMessageSender(MessageSenderWrapper):
                 window_label=window_label,
             ),
         )
+        self._persist_candidate_cohorts(repository=repository, view=view)
         return [build_crypto_signal_message(view)]
+
+    def _persist_candidate_cohorts(
+        self,
+        *,
+        repository: CryptoSignalRepository,
+        view,
+    ) -> None:
+        try:
+            repository.save_candidate_cohorts_from_view(view)
+        except Exception:
+            logger.warning(
+                'Failed to persist crypto signal candidate cohorts; continuing digest',
+                exc_info=True,
+            )
 
     def _is_fresh_enough(self, run_timestamp_utc: datetime.datetime) -> bool:
         if self.runtime_mode.bypass_schedule:

--- a/src/service/crypto_signal/models.py
+++ b/src/service/crypto_signal/models.py
@@ -2,6 +2,9 @@ import datetime
 from dataclasses import dataclass, field
 
 
+CALIBRATION_FOLLOW_UP_CONTEXT_TAG = 'calibration_follow_up'
+
+
 @dataclass(slots=True)
 class CryptoSignalRunRecord:
     run_timestamp_utc: datetime.datetime
@@ -120,3 +123,47 @@ class CryptoSignalDigestView:
     strong_candidates: list[CryptoSignalCandidate] = field(default_factory=list)
     weak_candidates: list[CryptoSignalCandidate] = field(default_factory=list)
     watchlist_candidates: list[CryptoSignalCandidate] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class CryptoSignalCandidateCohort:
+    signal_run_timestamp_utc: datetime.datetime
+    runtime_mode: str
+    window_label: str
+    section: str
+    coin_id: int
+    symbol: str
+    name: str
+    baseline_price_usd: float | None
+    latest_price_change_24h: float | None
+    window_price_change_pct: float | None
+    score: int
+    price_persistence_score: int
+    volume_confirmation_score: int
+    attention_persistence_score: int
+    breadth_alignment_score: int
+    observation_count: int
+    reason_tags: tuple[str, ...]
+    flags: tuple[str, ...]
+    market_regime_label: str
+    market_regime_reason: str
+    cohort_id: int | None = None
+    created_at_utc: datetime.datetime | None = None
+
+
+@dataclass(slots=True)
+class CryptoSignalCandidateOutcome:
+    cohort_id: int
+    outcome_window: str
+    target_timestamp_utc: datetime.datetime
+    status: str
+    candidate_price_usd: float | None = None
+    btc_price_usd: float | None = None
+    eth_price_usd: float | None = None
+    absolute_return_pct: float | None = None
+    btc_relative_return_pct: float | None = None
+    eth_relative_return_pct: float | None = None
+    missing_reason: str | None = None
+    resolved_run_timestamp_utc: datetime.datetime | None = None
+    created_at_utc: datetime.datetime | None = None
+    updated_at_utc: datetime.datetime | None = None

--- a/src/service/crypto_signal/repository.py
+++ b/src/service/crypto_signal/repository.py
@@ -927,6 +927,9 @@ class CryptoSignalRepository:
         view: CryptoSignalDigestView,
     ) -> list[CryptoSignalCandidateCohort]:
         cohorts = []
+        latest_coin_ids = {
+            coin.coin_id for coin in view.latest_snapshot.coins
+        }
         candidates_by_section = [
             ('strong', view.strong_candidates),
             ('weak', view.weak_candidates),
@@ -934,6 +937,12 @@ class CryptoSignalRepository:
         ]
         for section, candidates in candidates_by_section:
             for candidate in candidates:
+                if candidate.coin_id not in latest_coin_ids:
+                    # Watchlist rows can be carried from recent history for
+                    # operator continuity. Calibration needs a fresh baseline at
+                    # the signal timestamp, so stale display-only rows are not
+                    # frozen into outcome cohorts.
+                    continue
                 cohorts.append(
                     CryptoSignalCandidateCohort(
                         signal_run_timestamp_utc=view.latest_snapshot.run.run_timestamp_utc,
@@ -997,22 +1006,7 @@ class CryptoSignalRepository:
                 window_label,
                 section,
                 coin_id
-            ) DO UPDATE SET
-                symbol=excluded.symbol,
-                name=excluded.name,
-                baseline_price_usd=excluded.baseline_price_usd,
-                latest_price_change_24h=excluded.latest_price_change_24h,
-                window_price_change_pct=excluded.window_price_change_pct,
-                score=excluded.score,
-                price_persistence_score=excluded.price_persistence_score,
-                volume_confirmation_score=excluded.volume_confirmation_score,
-                attention_persistence_score=excluded.attention_persistence_score,
-                breadth_alignment_score=excluded.breadth_alignment_score,
-                observation_count=excluded.observation_count,
-                reason_tags_json=excluded.reason_tags_json,
-                flags_json=excluded.flags_json,
-                market_regime_label=excluded.market_regime_label,
-                market_regime_reason=excluded.market_regime_reason
+            ) DO NOTHING
             """,
             (
                 self._format_timestamp(cohort.signal_run_timestamp_utc),
@@ -1082,8 +1076,7 @@ class CryptoSignalRepository:
                 created_at_utc,
                 updated_at_utc
             ) VALUES (?, ?, ?, ?, ?, ?)
-            ON CONFLICT (cohort_id, outcome_window) DO UPDATE SET
-                target_timestamp_utc=excluded.target_timestamp_utc
+            ON CONFLICT (cohort_id, outcome_window) DO NOTHING
             """,
             [
                 (

--- a/src/service/crypto_signal/repository.py
+++ b/src/service/crypto_signal/repository.py
@@ -7,7 +7,10 @@ from typing import Iterable
 from src.config import config
 from src.runtime.runtime_mode import DEFAULT_RUNTIME_MODE, RuntimeMode
 from src.service.crypto_signal.models import (
+    CryptoSignalCandidateCohort,
+    CryptoSignalCandidateOutcome,
     CryptoSignalCoinSnapshot,
+    CryptoSignalDigestView,
     CryptoSignalMarketRegimeMetric,
     CryptoSignalMarketRegimeSnapshot,
     CryptoSignalRunRecord,
@@ -16,6 +19,17 @@ from src.service.crypto_signal.models import (
 
 
 SNAPSHOT_VERSION = 1
+BTC_COIN_ID = 1
+ETH_COIN_ID = 1027
+OUTCOME_WINDOWS = {
+    '24h': datetime.timedelta(days=1),
+    '3d': datetime.timedelta(days=3),
+    '7d': datetime.timedelta(days=7),
+}
+OUTCOME_MAX_FOLLOW_UP_LAG = datetime.timedelta(hours=12)
+OUTCOME_STATUS_PENDING = 'pending'
+OUTCOME_STATUS_RESOLVED = 'resolved'
+OUTCOME_STATUS_MISSING = 'missing'
 
 SCHEMA_DOCS = {
     'crypto_signal_metadata': {
@@ -82,6 +96,35 @@ SCHEMA_DOCS = {
         'unit': 'Metric unit, such as usd or percent.',
         'source_timestamp_utc': 'Provider source timestamp for the metric value.',
         'created_at_utc': 'UTC write timestamp for the persisted metric row.',
+    },
+    'crypto_signal_candidate_cohorts': {
+        'cohort_id': 'Synthetic emitted-candidate cohort identifier.',
+        'signal_run_timestamp_utc': 'UTC timestamp for the operator signal run.',
+        'runtime_mode': 'Runtime mode label used when the signal rendered.',
+        'window_label': 'Primary signal window used for ranking, such as 7d.',
+        'section': 'Rendered section that emitted the candidate.',
+        'coin_id': 'CMC coin identifier for the emitted candidate.',
+        'symbol': 'Candidate ticker symbol at render time.',
+        'name': 'Candidate display name at render time.',
+        'baseline_price_usd': 'Candidate price at render time.',
+        'score': 'Rendered candidate score.',
+        'reason_tags_json': 'Stable JSON array of rendered reason tags.',
+        'market_regime_label': 'Market-regime label rendered with the message.',
+        'market_regime_reason': 'Market-regime reason rendered with the message.',
+        'created_at_utc': 'UTC write timestamp for the cohort row.',
+    },
+    'crypto_signal_candidate_outcomes': {
+        'cohort_id': 'Foreign key to crypto_signal_candidate_cohorts.',
+        'outcome_window': 'Forward window such as 24h, 3d, or 7d.',
+        'target_timestamp_utc': 'UTC target timestamp for the forward outcome.',
+        'status': 'resolved or missing.',
+        'candidate_price_usd': 'Candidate price used for outcome calculation.',
+        'btc_price_usd': 'BTC benchmark price at the outcome timestamp.',
+        'eth_price_usd': 'ETH benchmark price at the outcome timestamp.',
+        'absolute_return_pct': 'Candidate forward return from baseline price.',
+        'btc_relative_return_pct': 'Candidate return minus BTC return.',
+        'eth_relative_return_pct': 'Candidate return minus ETH return.',
+        'missing_reason': 'Reason an outcome could not be resolved.',
     },
 }
 
@@ -221,6 +264,83 @@ class CryptoSignalRepository:
                 ON crypto_signal_market_regime_metrics (metric_name, source_timestamp_utc)
                 """
             )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS crypto_signal_candidate_cohorts (
+                    cohort_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    signal_run_timestamp_utc TEXT NOT NULL,
+                    runtime_mode TEXT NOT NULL,
+                    window_label TEXT NOT NULL,
+                    section TEXT NOT NULL,
+                    coin_id INTEGER NOT NULL,
+                    symbol TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    baseline_price_usd REAL NULL,
+                    latest_price_change_24h REAL NULL,
+                    window_price_change_pct REAL NULL,
+                    score INTEGER NOT NULL,
+                    price_persistence_score INTEGER NOT NULL,
+                    volume_confirmation_score INTEGER NOT NULL,
+                    attention_persistence_score INTEGER NOT NULL,
+                    breadth_alignment_score INTEGER NOT NULL,
+                    observation_count INTEGER NOT NULL,
+                    reason_tags_json TEXT NOT NULL,
+                    flags_json TEXT NOT NULL,
+                    market_regime_label TEXT NOT NULL,
+                    market_regime_reason TEXT NOT NULL,
+                    created_at_utc TEXT NOT NULL,
+                    UNIQUE (
+                        signal_run_timestamp_utc,
+                        runtime_mode,
+                        window_label,
+                        section,
+                        coin_id
+                    )
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_crypto_signal_candidate_cohorts_unresolved
+                ON crypto_signal_candidate_cohorts (
+                    runtime_mode,
+                    signal_run_timestamp_utc,
+                    coin_id
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS crypto_signal_candidate_outcomes (
+                    cohort_id INTEGER NOT NULL,
+                    outcome_window TEXT NOT NULL,
+                    target_timestamp_utc TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    candidate_price_usd REAL NULL,
+                    btc_price_usd REAL NULL,
+                    eth_price_usd REAL NULL,
+                    absolute_return_pct REAL NULL,
+                    btc_relative_return_pct REAL NULL,
+                    eth_relative_return_pct REAL NULL,
+                    missing_reason TEXT NULL,
+                    resolved_run_timestamp_utc TEXT NULL,
+                    created_at_utc TEXT NOT NULL,
+                    updated_at_utc TEXT NOT NULL,
+                    PRIMARY KEY (cohort_id, outcome_window),
+                    FOREIGN KEY (cohort_id)
+                        REFERENCES crypto_signal_candidate_cohorts(cohort_id)
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_crypto_signal_candidate_outcomes_due
+                ON crypto_signal_candidate_outcomes (
+                    status,
+                    target_timestamp_utc
+                )
+                """
+            )
             # Current phase-1 reads filter one run via the (run_id, coin_id)
             # primary key, then sort a small per-run coin set in memory. Add a
             # (run_id, symbol, coin_id) index only if that per-run sort becomes
@@ -332,6 +452,120 @@ class CryptoSignalRepository:
             coin.run_id = run_id
             coin.created_at_utc = created_at_utc
         return snapshot
+
+    def save_candidate_cohorts_from_view(
+        self,
+        view: CryptoSignalDigestView,
+    ) -> list[CryptoSignalCandidateCohort]:
+        self.init_schema()
+        created_at_utc = self._utcnow()
+        cohorts = self._build_candidate_cohorts(view=view)
+        if len(cohorts) == 0:
+            return []
+
+        with self._connect() as connection:
+            for cohort in cohorts:
+                self._upsert_candidate_cohort(
+                    connection=connection,
+                    cohort=cohort,
+                    created_at_utc=created_at_utc,
+                )
+                cohort_id = self._select_candidate_cohort_id(
+                    connection=connection,
+                    cohort=cohort,
+                )
+                cohort.cohort_id = cohort_id
+                cohort.created_at_utc = created_at_utc
+                self._upsert_candidate_outcome_placeholders(
+                    connection=connection,
+                    cohort=cohort,
+                    created_at_utc=created_at_utc,
+                )
+            connection.commit()
+        return cohorts
+
+    def get_unresolved_candidate_follow_up_entries(
+        self,
+        runtime_mode: str,
+        current_timestamp_utc: datetime.datetime,
+    ) -> list[tuple[str, int]]:
+        if not Path(self.db_path).exists():
+            return []
+        with self._connect() as connection:
+            try:
+                rows = connection.execute(
+                    """
+                    SELECT DISTINCT cohort.symbol, cohort.coin_id
+                    FROM crypto_signal_candidate_cohorts AS cohort
+                    INNER JOIN crypto_signal_candidate_outcomes AS outcome
+                      ON outcome.cohort_id = cohort.cohort_id
+                    WHERE cohort.runtime_mode = ?
+                      AND outcome.status NOT IN (?, ?)
+                      AND outcome.target_timestamp_utc <= ?
+                    ORDER BY cohort.symbol ASC, cohort.coin_id ASC
+                    """,
+                    (
+                        runtime_mode,
+                        OUTCOME_STATUS_RESOLVED,
+                        OUTCOME_STATUS_MISSING,
+                        self._format_timestamp(current_timestamp_utc),
+                    ),
+                ).fetchall()
+            except sqlite3.OperationalError as error:
+                if 'no such table' in str(error):
+                    return []
+                raise
+        return [(row['symbol'], int(row['coin_id'])) for row in rows]
+
+    def resolve_due_candidate_outcomes(
+        self,
+        runtime_mode: str,
+        current_timestamp_utc: datetime.datetime,
+    ) -> list[CryptoSignalCandidateOutcome]:
+        if not Path(self.db_path).exists():
+            return []
+        self.init_schema()
+        updated_at_utc = self._utcnow()
+
+        with self._connect() as connection:
+            due_rows = connection.execute(
+                """
+                SELECT
+                    outcome.*,
+                    cohort.signal_run_timestamp_utc,
+                    cohort.runtime_mode,
+                    cohort.coin_id,
+                    cohort.baseline_price_usd
+                FROM crypto_signal_candidate_outcomes AS outcome
+                INNER JOIN crypto_signal_candidate_cohorts AS cohort
+                  ON cohort.cohort_id = outcome.cohort_id
+                WHERE cohort.runtime_mode = ?
+                  AND outcome.status NOT IN (?, ?)
+                  AND outcome.target_timestamp_utc <= ?
+                ORDER BY outcome.target_timestamp_utc ASC, cohort.coin_id ASC
+                """,
+                (
+                    runtime_mode,
+                    OUTCOME_STATUS_RESOLVED,
+                    OUTCOME_STATUS_MISSING,
+                    self._format_timestamp(current_timestamp_utc),
+                ),
+            ).fetchall()
+            resolved_outcomes = []
+            for row in due_rows:
+                outcome = self._resolve_candidate_outcome_row(
+                    connection=connection,
+                    row=row,
+                    updated_at_utc=updated_at_utc,
+                )
+                self._update_candidate_outcome(
+                    connection=connection,
+                    outcome=outcome,
+                    updated_at_utc=updated_at_utc,
+                )
+                resolved_outcomes.append(outcome)
+            connection.commit()
+        return resolved_outcomes
 
     def save_market_regime_snapshot(
         self,
@@ -688,6 +922,402 @@ class CryptoSignalRepository:
             coins=[self._build_coin_snapshot(row) for row in coin_rows],
         )
 
+    def _build_candidate_cohorts(
+        self,
+        view: CryptoSignalDigestView,
+    ) -> list[CryptoSignalCandidateCohort]:
+        cohorts = []
+        candidates_by_section = [
+            ('strong', view.strong_candidates),
+            ('weak', view.weak_candidates),
+            ('watchlist', view.watchlist_candidates),
+        ]
+        for section, candidates in candidates_by_section:
+            for candidate in candidates:
+                cohorts.append(
+                    CryptoSignalCandidateCohort(
+                        signal_run_timestamp_utc=view.latest_snapshot.run.run_timestamp_utc,
+                        runtime_mode=view.latest_snapshot.run.runtime_mode,
+                        window_label=view.window_label,
+                        section=section,
+                        coin_id=candidate.coin_id,
+                        symbol=candidate.symbol,
+                        name=candidate.name,
+                        baseline_price_usd=candidate.latest_price_usd,
+                        latest_price_change_24h=candidate.latest_price_change_24h,
+                        window_price_change_pct=candidate.window_price_change_pct,
+                        score=candidate.score,
+                        price_persistence_score=candidate.price_persistence_score,
+                        volume_confirmation_score=candidate.volume_confirmation_score,
+                        attention_persistence_score=candidate.attention_persistence_score,
+                        breadth_alignment_score=candidate.breadth_alignment_score,
+                        observation_count=candidate.observation_count,
+                        reason_tags=candidate.reason_tags,
+                        flags=candidate.flags,
+                        market_regime_label=view.market_regime_label,
+                        market_regime_reason=view.market_regime_reason,
+                    )
+                )
+        return cohorts
+
+    def _upsert_candidate_cohort(
+        self,
+        connection: sqlite3.Connection,
+        cohort: CryptoSignalCandidateCohort,
+        created_at_utc: datetime.datetime,
+    ) -> None:
+        connection.execute(
+            """
+            INSERT INTO crypto_signal_candidate_cohorts (
+                signal_run_timestamp_utc,
+                runtime_mode,
+                window_label,
+                section,
+                coin_id,
+                symbol,
+                name,
+                baseline_price_usd,
+                latest_price_change_24h,
+                window_price_change_pct,
+                score,
+                price_persistence_score,
+                volume_confirmation_score,
+                attention_persistence_score,
+                breadth_alignment_score,
+                observation_count,
+                reason_tags_json,
+                flags_json,
+                market_regime_label,
+                market_regime_reason,
+                created_at_utc
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (
+                signal_run_timestamp_utc,
+                runtime_mode,
+                window_label,
+                section,
+                coin_id
+            ) DO UPDATE SET
+                symbol=excluded.symbol,
+                name=excluded.name,
+                baseline_price_usd=excluded.baseline_price_usd,
+                latest_price_change_24h=excluded.latest_price_change_24h,
+                window_price_change_pct=excluded.window_price_change_pct,
+                score=excluded.score,
+                price_persistence_score=excluded.price_persistence_score,
+                volume_confirmation_score=excluded.volume_confirmation_score,
+                attention_persistence_score=excluded.attention_persistence_score,
+                breadth_alignment_score=excluded.breadth_alignment_score,
+                observation_count=excluded.observation_count,
+                reason_tags_json=excluded.reason_tags_json,
+                flags_json=excluded.flags_json,
+                market_regime_label=excluded.market_regime_label,
+                market_regime_reason=excluded.market_regime_reason
+            """,
+            (
+                self._format_timestamp(cohort.signal_run_timestamp_utc),
+                cohort.runtime_mode,
+                cohort.window_label,
+                cohort.section,
+                cohort.coin_id,
+                cohort.symbol,
+                cohort.name,
+                cohort.baseline_price_usd,
+                cohort.latest_price_change_24h,
+                cohort.window_price_change_pct,
+                cohort.score,
+                cohort.price_persistence_score,
+                cohort.volume_confirmation_score,
+                cohort.attention_persistence_score,
+                cohort.breadth_alignment_score,
+                cohort.observation_count,
+                json.dumps(list(cohort.reason_tags), separators=(',', ':')),
+                json.dumps(list(cohort.flags), separators=(',', ':')),
+                cohort.market_regime_label,
+                cohort.market_regime_reason,
+                self._format_timestamp(created_at_utc),
+            ),
+        )
+
+    def _select_candidate_cohort_id(
+        self,
+        connection: sqlite3.Connection,
+        cohort: CryptoSignalCandidateCohort,
+    ) -> int:
+        row = connection.execute(
+            """
+            SELECT cohort_id
+            FROM crypto_signal_candidate_cohorts
+            WHERE signal_run_timestamp_utc = ?
+              AND runtime_mode = ?
+              AND window_label = ?
+              AND section = ?
+              AND coin_id = ?
+            """,
+            (
+                self._format_timestamp(cohort.signal_run_timestamp_utc),
+                cohort.runtime_mode,
+                cohort.window_label,
+                cohort.section,
+                cohort.coin_id,
+            ),
+        ).fetchone()
+        return int(row['cohort_id'])
+
+    def _upsert_candidate_outcome_placeholders(
+        self,
+        connection: sqlite3.Connection,
+        cohort: CryptoSignalCandidateCohort,
+        created_at_utc: datetime.datetime,
+    ) -> None:
+        if cohort.cohort_id is None:
+            raise ValueError('candidate cohort must be persisted before outcomes')
+        connection.executemany(
+            """
+            INSERT INTO crypto_signal_candidate_outcomes (
+                cohort_id,
+                outcome_window,
+                target_timestamp_utc,
+                status,
+                created_at_utc,
+                updated_at_utc
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT (cohort_id, outcome_window) DO UPDATE SET
+                target_timestamp_utc=excluded.target_timestamp_utc
+            """,
+            [
+                (
+                    cohort.cohort_id,
+                    outcome_window,
+                    self._format_timestamp(
+                        cohort.signal_run_timestamp_utc + outcome_delta
+                    ),
+                    OUTCOME_STATUS_PENDING,
+                    self._format_timestamp(created_at_utc),
+                    self._format_timestamp(created_at_utc),
+                )
+                for outcome_window, outcome_delta in OUTCOME_WINDOWS.items()
+            ],
+        )
+
+    def _resolve_candidate_outcome_row(
+        self,
+        connection: sqlite3.Connection,
+        row: sqlite3.Row,
+        updated_at_utc: datetime.datetime,
+    ) -> CryptoSignalCandidateOutcome:
+        target_timestamp_utc = self._parse_timestamp(row['target_timestamp_utc'])
+        outcome_run = self._find_first_run_at_or_after(
+            connection=connection,
+            runtime_mode=row['runtime_mode'],
+            target_timestamp_utc=target_timestamp_utc,
+        )
+        if outcome_run is None:
+            return CryptoSignalCandidateOutcome(
+                cohort_id=row['cohort_id'],
+                outcome_window=row['outcome_window'],
+                target_timestamp_utc=target_timestamp_utc,
+                status=OUTCOME_STATUS_MISSING,
+                missing_reason='missing_follow_up_run',
+                updated_at_utc=updated_at_utc,
+            )
+        resolved_run_timestamp_utc = self._parse_timestamp(
+            outcome_run['run_timestamp_utc']
+        )
+        if resolved_run_timestamp_utc - target_timestamp_utc > OUTCOME_MAX_FOLLOW_UP_LAG:
+            return CryptoSignalCandidateOutcome(
+                cohort_id=row['cohort_id'],
+                outcome_window=row['outcome_window'],
+                target_timestamp_utc=target_timestamp_utc,
+                status=OUTCOME_STATUS_MISSING,
+                missing_reason='stale_follow_up_run',
+                resolved_run_timestamp_utc=resolved_run_timestamp_utc,
+                updated_at_utc=updated_at_utc,
+            )
+
+        prices = self._get_prices_for_run(
+            connection=connection,
+            run_id=int(outcome_run['run_id']),
+            coin_ids=[int(row['coin_id']), BTC_COIN_ID, ETH_COIN_ID],
+        )
+        baseline_price_usd = row['baseline_price_usd']
+        candidate_price_usd = prices.get(int(row['coin_id']))
+        btc_price_usd = prices.get(BTC_COIN_ID)
+        eth_price_usd = prices.get(ETH_COIN_ID)
+        baseline_run = self._find_run_by_timestamp(
+            connection=connection,
+            runtime_mode=row['runtime_mode'],
+            run_timestamp_utc=self._parse_timestamp(row['signal_run_timestamp_utc']),
+        )
+        baseline_prices = (
+            {}
+            if baseline_run is None
+            else self._get_prices_for_run(
+                connection=connection,
+                run_id=int(baseline_run['run_id']),
+                coin_ids=[BTC_COIN_ID, ETH_COIN_ID],
+            )
+        )
+        btc_baseline_price_usd = baseline_prices.get(BTC_COIN_ID)
+        eth_baseline_price_usd = baseline_prices.get(ETH_COIN_ID)
+
+        missing_reasons = []
+        if baseline_price_usd is None:
+            missing_reasons.append('missing_candidate_baseline_price')
+        if candidate_price_usd is None:
+            missing_reasons.append('missing_candidate_follow_up_price')
+        if btc_baseline_price_usd is None or btc_price_usd is None:
+            missing_reasons.append('missing_btc_benchmark_price')
+        if eth_baseline_price_usd is None or eth_price_usd is None:
+            missing_reasons.append('missing_eth_benchmark_price')
+        if missing_reasons:
+            return CryptoSignalCandidateOutcome(
+                cohort_id=row['cohort_id'],
+                outcome_window=row['outcome_window'],
+                target_timestamp_utc=target_timestamp_utc,
+                status=OUTCOME_STATUS_MISSING,
+                candidate_price_usd=candidate_price_usd,
+                btc_price_usd=btc_price_usd,
+                eth_price_usd=eth_price_usd,
+                missing_reason=','.join(missing_reasons),
+                resolved_run_timestamp_utc=resolved_run_timestamp_utc,
+                updated_at_utc=updated_at_utc,
+            )
+
+        absolute_return_pct = _calculate_return_pct(
+            baseline_price_usd,
+            candidate_price_usd,
+        )
+        btc_return_pct = _calculate_return_pct(
+            btc_baseline_price_usd,
+            btc_price_usd,
+        )
+        eth_return_pct = _calculate_return_pct(
+            eth_baseline_price_usd,
+            eth_price_usd,
+        )
+        return CryptoSignalCandidateOutcome(
+            cohort_id=row['cohort_id'],
+            outcome_window=row['outcome_window'],
+            target_timestamp_utc=target_timestamp_utc,
+            status=OUTCOME_STATUS_RESOLVED,
+            candidate_price_usd=candidate_price_usd,
+            btc_price_usd=btc_price_usd,
+            eth_price_usd=eth_price_usd,
+            absolute_return_pct=absolute_return_pct,
+            btc_relative_return_pct=(
+                None
+                if absolute_return_pct is None or btc_return_pct is None
+                else absolute_return_pct - btc_return_pct
+            ),
+            eth_relative_return_pct=(
+                None
+                if absolute_return_pct is None or eth_return_pct is None
+                else absolute_return_pct - eth_return_pct
+            ),
+            resolved_run_timestamp_utc=resolved_run_timestamp_utc,
+            updated_at_utc=updated_at_utc,
+        )
+
+    def _update_candidate_outcome(
+        self,
+        connection: sqlite3.Connection,
+        outcome: CryptoSignalCandidateOutcome,
+        updated_at_utc: datetime.datetime,
+    ) -> None:
+        connection.execute(
+            """
+            UPDATE crypto_signal_candidate_outcomes
+            SET status = ?,
+                candidate_price_usd = ?,
+                btc_price_usd = ?,
+                eth_price_usd = ?,
+                absolute_return_pct = ?,
+                btc_relative_return_pct = ?,
+                eth_relative_return_pct = ?,
+                missing_reason = ?,
+                resolved_run_timestamp_utc = ?,
+                updated_at_utc = ?
+            WHERE cohort_id = ?
+              AND outcome_window = ?
+            """,
+            (
+                outcome.status,
+                outcome.candidate_price_usd,
+                outcome.btc_price_usd,
+                outcome.eth_price_usd,
+                outcome.absolute_return_pct,
+                outcome.btc_relative_return_pct,
+                outcome.eth_relative_return_pct,
+                outcome.missing_reason,
+                (
+                    None
+                    if outcome.resolved_run_timestamp_utc is None
+                    else self._format_timestamp(outcome.resolved_run_timestamp_utc)
+                ),
+                self._format_timestamp(updated_at_utc),
+                outcome.cohort_id,
+                outcome.outcome_window,
+            ),
+        )
+
+    def _find_first_run_at_or_after(
+        self,
+        connection: sqlite3.Connection,
+        runtime_mode: str,
+        target_timestamp_utc: datetime.datetime,
+    ) -> sqlite3.Row | None:
+        return connection.execute(
+            """
+            SELECT *
+            FROM crypto_signal_runs
+            WHERE runtime_mode = ?
+              AND run_timestamp_utc >= ?
+            ORDER BY run_timestamp_utc ASC
+            LIMIT 1
+            """,
+            (runtime_mode, self._format_timestamp(target_timestamp_utc)),
+        ).fetchone()
+
+    def _find_run_by_timestamp(
+        self,
+        connection: sqlite3.Connection,
+        runtime_mode: str,
+        run_timestamp_utc: datetime.datetime,
+    ) -> sqlite3.Row | None:
+        return connection.execute(
+            """
+            SELECT *
+            FROM crypto_signal_runs
+            WHERE runtime_mode = ?
+              AND run_timestamp_utc = ?
+            LIMIT 1
+            """,
+            (runtime_mode, self._format_timestamp(run_timestamp_utc)),
+        ).fetchone()
+
+    def _get_prices_for_run(
+        self,
+        connection: sqlite3.Connection,
+        run_id: int,
+        coin_ids: list[int],
+    ) -> dict[int, float]:
+        placeholders = ','.join('?' for _ in coin_ids)
+        rows = connection.execute(
+            f"""
+            SELECT coin_id, price_usd
+            FROM crypto_signal_coin_snapshots
+            WHERE run_id = ?
+              AND coin_id IN ({placeholders})
+              AND price_usd IS NOT NULL
+            """,
+            [run_id, *coin_ids],
+        ).fetchall()
+        return {
+            int(row['coin_id']): float(row['price_usd'])
+            for row in rows
+        }
+
     def _build_run_record(self, row: sqlite3.Row) -> CryptoSignalRunRecord:
         return CryptoSignalRunRecord(
             run_id=row['run_id'],
@@ -848,6 +1478,17 @@ def _market_regime_row_version_key(row: sqlite3.Row) -> tuple[str, str, int]:
         row['created_at_utc'],
         int(row['snapshot_id']),
     )
+
+
+def _calculate_return_pct(
+    baseline_price_usd: float | None,
+    outcome_price_usd: float | None,
+) -> float | None:
+    if baseline_price_usd is None or outcome_price_usd is None:
+        return None
+    if baseline_price_usd == 0:
+        return None
+    return ((outcome_price_usd - baseline_price_usd) / baseline_price_usd) * 100
 
 
 def iter_snapshot_coin_ids(

--- a/src/service/crypto_signal/scorer.py
+++ b/src/service/crypto_signal/scorer.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from statistics import mean
 
 from src.service.crypto_signal.models import (
+    CALIBRATION_FOLLOW_UP_CONTEXT_TAG,
     CryptoSignalCandidate,
     CryptoSignalCoinSnapshot,
     CryptoSignalDigestView,
@@ -90,6 +91,11 @@ def build_digest_view(
         candidate
         for candidate in candidates
         if candidate.score >= 2
+        and _is_operator_rankable_scope(
+            candidate=candidate,
+            tracked_universe_coin_ids=tracked_universe_coin_ids,
+            watchlist_coin_ids=watchlist_coin_ids,
+        )
         and _is_rankable_candidate(
             candidate=candidate,
             tracked_universe_coin_ids=tracked_universe_coin_ids,
@@ -101,6 +107,11 @@ def build_digest_view(
         candidate
         for candidate in candidates
         if candidate.score <= -2
+        and _is_operator_rankable_scope(
+            candidate=candidate,
+            tracked_universe_coin_ids=tracked_universe_coin_ids,
+            watchlist_coin_ids=watchlist_coin_ids,
+        )
         and _is_rankable_candidate(
             candidate=candidate,
             tracked_universe_coin_ids=tracked_universe_coin_ids,
@@ -353,6 +364,19 @@ def _is_rankable_candidate(
     return (
         candidate.latest_price_usd >= min_dynamic_price_usd
         and candidate.latest_volume_24h >= min_dynamic_volume_24h
+    )
+
+
+def _is_operator_rankable_scope(
+    candidate: CryptoSignalCandidate,
+    tracked_universe_coin_ids: set[int],
+    watchlist_coin_ids: set[int],
+) -> bool:
+    if CALIBRATION_FOLLOW_UP_CONTEXT_TAG not in candidate.latest_context_tags:
+        return True
+    return (
+        candidate.coin_id in tracked_universe_coin_ids
+        or candidate.coin_id in watchlist_coin_ids
     )
 
 

--- a/src/service/crypto_signal/snapshot_builder.py
+++ b/src/service/crypto_signal/snapshot_builder.py
@@ -15,6 +15,7 @@ from src.job.crypto.crypto_digest_formatter import (
 )
 from src.runtime.runtime_mode import RuntimeMode
 from src.service.crypto_signal.models import (
+    CALIBRATION_FOLLOW_UP_CONTEXT_TAG,
     CryptoSignalCoinSnapshot,
     CryptoSignalRunRecord,
     CryptoSignalSnapshot,
@@ -32,6 +33,7 @@ CONTEXT_TAG_ORDER = (
     'sector_leader_weakest',
     'sector_loser_weakest',
     'watchlist',
+    CALIBRATION_FOLLOW_UP_CONTEXT_TAG,
 )
 
 _SPOTLIGHT_REASON_TO_TAG = {

--- a/tests/unit/job/crypto/crypto_digest_message_sender_test.py
+++ b/tests/unit/job/crypto/crypto_digest_message_sender_test.py
@@ -4,6 +4,7 @@ import datetime
 import json
 import os
 import typing
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -12,6 +13,7 @@ from market_data_library.types import cmc_type
 
 from src.job.crypto.crypto_digest_message_sender import CryptoDigestMessageSender
 from src.runtime.runtime_mode import DEFAULT_RUNTIME_MODE
+from src.service.crypto_signal.models import CALIBRATION_FOLLOW_UP_CONTEXT_TAG
 from src.type.sentiment import FearGreedAverage, FearGreedData, FearGreedResult
 
 
@@ -176,6 +178,10 @@ class TestCryptoDigestMessageSender:
         sentiment_service = AsyncMock()
         signal_repository = Mock()
         signal_repository.get_coin_observation_counts_since = Mock(return_value={})
+        signal_repository.get_unresolved_candidate_follow_up_entries = Mock(
+            return_value=[]
+        )
+        signal_repository.resolve_due_candidate_outcomes = Mock(return_value=[])
         signal_repository.save_or_merge_snapshot = Mock()
         signal_backfill_service = AsyncMock()
         signal_backfill_service.build_snapshots = AsyncMock(return_value=[])
@@ -375,6 +381,98 @@ class TestCryptoDigestMessageSender:
         message_sender.signal_repository.init_schema.assert_called_once()
         message_sender.signal_repository.save_snapshot.assert_called_once()
         message_sender.signal_backfill_service.build_snapshots.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_format_message_collects_due_candidate_follow_up_entries(self):
+        strongest_sector = copy.deepcopy(self.sector_24h_change[0])
+        strongest_sector.sectorId = 'video'
+
+        weakest_sector = copy.deepcopy(self.sector_24h_change[0])
+        weakest_sector.sectorId = 'defi'
+        weakest_sector.title = 'DeFi'
+        weakest_sector.avgPriceChange = -4.8
+
+        message_sender = self.build_message_sender()
+        message_sender.signal_repository.get_unresolved_candidate_follow_up_entries = Mock(
+            return_value=[('RENDER', 5690)]
+        )
+        message_sender.signal_repository.get_coin_observation_counts_since = Mock(
+            return_value={1: 5, 1027: 5, 5426: 5, 5690: 5}
+        )
+        message_sender.sentiment_service.get_crypto_fear_greed_index = AsyncMock(
+            return_value=self.sentiment
+        )
+        message_sender.cmc_service.get_sectors_24h_change = AsyncMock(
+            side_effect=[[strongest_sector], [weakest_sector]]
+        )
+        message_sender.cmc_service.get_spotlight = AsyncMock(return_value=self.spotlight)
+        message_sender.cmc_service.get_coin_detail = AsyncMock(return_value=self.coin_detail)
+        message_sender.cmc_service.get_sector_detail = AsyncMock(
+            side_effect=RuntimeError('403 Forbidden')
+        )
+
+        messages = await message_sender.format_message()
+
+        assert len(messages) == 1
+        message_sender.cmc_service.get_coin_detail.assert_any_await(id=5690)
+        message_sender.cmc_service.get_coin_detail.assert_any_await(id=1)
+        message_sender.cmc_service.get_coin_detail.assert_any_await(id=1027)
+        saved_snapshot = message_sender.signal_repository.save_snapshot.call_args.args[0]
+        follow_up_coin = next(coin for coin in saved_snapshot.coins if coin.coin_id == 5690)
+        assert CALIBRATION_FOLLOW_UP_CONTEXT_TAG in follow_up_coin.context_tags
+        message_sender.signal_repository.resolve_due_candidate_outcomes.assert_called_once()
+
+    def test_follow_up_tag_keeps_current_operator_discovery_context_rankable(self):
+        message_sender = self.build_message_sender()
+        snapshot = SimpleNamespace(
+            coins=[
+                SimpleNamespace(
+                    coin_id=5690,
+                    context_tags=('spotlight_trending', 'spotlight_gainer'),
+                )
+            ]
+        )
+
+        message_sender._mark_calibration_follow_up_only_coins(
+            snapshot=snapshot,
+            candidate_follow_up_entries=[('RENDER', 5690)],
+        )
+
+        assert CALIBRATION_FOLLOW_UP_CONTEXT_TAG not in snapshot.coins[0].context_tags
+
+    @pytest.mark.asyncio
+    async def test_format_message_continues_when_candidate_outcome_resolution_fails(
+        self,
+    ):
+        strongest_sector = copy.deepcopy(self.sector_24h_change[0])
+        strongest_sector.sectorId = 'video'
+
+        weakest_sector = copy.deepcopy(self.sector_24h_change[0])
+        weakest_sector.sectorId = 'defi'
+        weakest_sector.title = 'DeFi'
+        weakest_sector.avgPriceChange = -4.8
+
+        message_sender = self.build_message_sender()
+        message_sender.signal_repository.resolve_due_candidate_outcomes = Mock(
+            side_effect=RuntimeError('database is locked')
+        )
+        message_sender.sentiment_service.get_crypto_fear_greed_index = AsyncMock(
+            return_value=self.sentiment
+        )
+        message_sender.cmc_service.get_sectors_24h_change = AsyncMock(
+            side_effect=[[strongest_sector], [weakest_sector]]
+        )
+        message_sender.cmc_service.get_spotlight = AsyncMock(return_value=self.spotlight)
+        message_sender.cmc_service.get_coin_detail = AsyncMock(return_value=self.coin_detail)
+        message_sender.cmc_service.get_sector_detail = AsyncMock(
+            side_effect=RuntimeError('403 Forbidden')
+        )
+
+        messages = await message_sender.format_message()
+
+        assert len(messages) == 1
+        assert '*Crypto market digest*' in messages[0]
+        message_sender.signal_repository.save_snapshot.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_market_regime_collection_is_disabled_by_default(self, monkeypatch):

--- a/tests/unit/job/crypto/crypto_signal_digest_message_sender_test.py
+++ b/tests/unit/job/crypto/crypto_signal_digest_message_sender_test.py
@@ -91,6 +91,7 @@ class _FakeRepository:
     ):
         self.latest_snapshot = latest_snapshot
         self.history = [latest_snapshot] if history is None else history
+        self.saved_cohort_view = None
 
     def get_latest_snapshot(self):
         return self.latest_snapshot
@@ -99,6 +100,10 @@ class _FakeRepository:
         return self.history
 
     def get_market_regime_metrics(self, **_kwargs):
+        return []
+
+    def save_candidate_cohorts_from_view(self, view):
+        self.saved_cohort_view = view
         return []
 
 
@@ -134,12 +139,11 @@ async def test_format_message_builds_operator_digest(monkeypatch):
         datetime.datetime(2026, 4, 21, 8, 45, tzinfo=datetime.timezone.utc)
     )
 
-    sender = _build_sender(
-        _FakeRepository(
-            latest_snapshot,
-            history=[earlier_snapshot, latest_snapshot],
-        ),
+    repository = _FakeRepository(
+        latest_snapshot,
+        history=[earlier_snapshot, latest_snapshot],
     )
+    sender = _build_sender(repository)
 
     monkeypatch.setattr(
         'src.job.crypto.crypto_signal_digest_message_sender.get_current_datetime',
@@ -153,6 +157,43 @@ async def test_format_message_builds_operator_digest(monkeypatch):
     assert '*Strong 7d momentum*' in messages[0]
     assert '7d \\+22\\.82%' in messages[0]
     assert '*Watchlist*' in messages[0]
+    assert 'Solana' in messages[0]
+    assert repository.saved_cohort_view is not None
+    assert repository.saved_cohort_view.latest_snapshot == latest_snapshot
+
+
+@pytest.mark.asyncio
+async def test_format_message_fails_open_when_candidate_cohort_save_fails(
+    monkeypatch,
+):
+    earlier_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 20, 8, 45, tzinfo=datetime.timezone.utc),
+        sol_price_usd=150.0,
+    )
+    latest_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 21, 8, 45, tzinfo=datetime.timezone.utc)
+    )
+
+    class _FailingRepository(_FakeRepository):
+        def save_candidate_cohorts_from_view(self, view):
+            raise RuntimeError('sqlite unavailable')
+
+    sender = _build_sender(
+        _FailingRepository(
+            latest_snapshot,
+            history=[earlier_snapshot, latest_snapshot],
+        )
+    )
+
+    monkeypatch.setattr(
+        'src.job.crypto.crypto_signal_digest_message_sender.get_current_datetime',
+        lambda: datetime.datetime(2026, 4, 21, 9, 0, tzinfo=datetime.timezone.utc),
+    )
+
+    messages = await sender.format_message()
+
+    assert len(messages) == 1
+    assert '*Crypto trend signal*' in messages[0]
     assert 'Solana' in messages[0]
 
 

--- a/tests/unit/service/crypto_signal/repository_test.py
+++ b/tests/unit/service/crypto_signal/repository_test.py
@@ -2,7 +2,9 @@ import datetime
 import sqlite3
 
 from src.service.crypto_signal.models import (
+    CryptoSignalCandidate,
     CryptoSignalCoinSnapshot,
+    CryptoSignalDigestView,
     CryptoSignalMarketRegimeMetric,
     CryptoSignalMarketRegimeSnapshot,
     CryptoSignalRunRecord,
@@ -14,6 +16,113 @@ from src.service.crypto_signal.market_regime import (
 )
 from src.service.crypto_signal.repository import CryptoSignalRepository
 from src.runtime.runtime_mode import RuntimeMode
+
+
+def _build_snapshot_at(
+    run_timestamp_utc: datetime.datetime,
+    *,
+    sol_price_usd: float | None = 100.0,
+    btc_price_usd: float | None = 100_000.0,
+    eth_price_usd: float | None = 4_000.0,
+) -> CryptoSignalSnapshot:
+    coins = [
+        CryptoSignalCoinSnapshot(
+            coin_id=1,
+            symbol='BTC',
+            name='Bitcoin',
+            price_usd=btc_price_usd,
+            price_change_24h=2.4,
+            volume_24h=31_000_000_000,
+            volume_change_pct_24h=7.5,
+            is_watchlist=True,
+            context_tags=('watchlist',),
+        ),
+        CryptoSignalCoinSnapshot(
+            coin_id=1027,
+            symbol='ETH',
+            name='Ethereum',
+            price_usd=eth_price_usd,
+            price_change_24h=1.7,
+            volume_24h=19_000_000_000,
+            volume_change_pct_24h=5.2,
+            is_watchlist=True,
+            context_tags=('watchlist',),
+        ),
+    ]
+    if sol_price_usd is not None:
+        coins.append(
+            CryptoSignalCoinSnapshot(
+                coin_id=5426,
+                symbol='SOL',
+                name='Solana',
+                price_usd=sol_price_usd,
+                price_change_24h=11.4,
+                volume_24h=4_820_000_000,
+                volume_change_pct_24h=27.1,
+                is_watchlist=True,
+                context_tags=('watchlist',),
+            )
+        )
+    return CryptoSignalSnapshot(
+        run=CryptoSignalRunRecord(
+            run_timestamp_utc=run_timestamp_utc,
+            runtime_mode='prod',
+            source_name='CMC + Alternative.me',
+            snapshot_version=1,
+            sentiment_now_value=63.0,
+            sentiment_now_label='Greed',
+            sentiment_yesterday_value=58.0,
+            sentiment_last_week_value=49.0,
+            sentiment_7d_avg=55.4,
+            sentiment_30d_avg=51.8,
+            strongest_sector_id='ai-big-data',
+            strongest_sector_name='AI & Big Data',
+            strongest_sector_avg_price_change_24h=8.4,
+            strongest_sector_market_change_24h=6.9,
+            strongest_sector_volume_change_24h=21.7,
+            strongest_sector_gainers_num=18,
+            strongest_sector_losers_num=5,
+            weakest_sector_id='gaming',
+            weakest_sector_name='Gaming',
+            weakest_sector_avg_price_change_24h=-6.1,
+            weakest_sector_market_change_24h=-4.8,
+            weakest_sector_volume_change_24h=-12.3,
+            weakest_sector_gainers_num=4,
+            weakest_sector_losers_num=19,
+        ),
+        coins=coins,
+    )
+
+
+def _build_digest_view(snapshot: CryptoSignalSnapshot) -> CryptoSignalDigestView:
+    return CryptoSignalDigestView(
+        latest_snapshot=snapshot,
+        window_label='7d',
+        market_regime_label='Mixed',
+        market_regime_reason='OI +2.4%, avg funding -0.0028%',
+        strong_candidates=[
+            CryptoSignalCandidate(
+                coin_id=5426,
+                symbol='SOL',
+                name='Solana',
+                latest_price_usd=100.0,
+                latest_volume_24h=4_820_000_000,
+                latest_price_change_24h=11.4,
+                window_price_change_pct=22.8,
+                latest_volume_change_pct_24h=27.1,
+                latest_context_tags=('watchlist',),
+                score=4,
+                price_persistence_score=2,
+                volume_confirmation_score=1,
+                attention_persistence_score=1,
+                breadth_alignment_score=0,
+                observation_count=7,
+                reason_tags=('price-persistence', 'volume-confirmation'),
+                flags=(),
+                is_watchlist=True,
+            )
+        ],
+    )
 
 
 def test_save_snapshot_and_load_latest_snapshot(tmp_path):
@@ -204,6 +313,198 @@ def test_get_latest_snapshot_returns_none_when_db_is_missing(tmp_path):
 
     assert repository.get_latest_snapshot() is None
     assert not (tmp_path / 'missing_crypto_signal.sqlite3').exists()
+
+
+def test_save_candidate_cohorts_from_view_is_idempotent(tmp_path):
+    db_path = tmp_path / 'crypto_signal.sqlite3'
+    repository = CryptoSignalRepository(db_path=str(db_path))
+    snapshot = _build_snapshot_at(
+        datetime.datetime(2026, 5, 1, 8, 0, tzinfo=datetime.timezone.utc)
+    )
+    view = _build_digest_view(snapshot)
+
+    first_save = repository.save_candidate_cohorts_from_view(view)
+    second_save = repository.save_candidate_cohorts_from_view(view)
+
+    connection = sqlite3.connect(db_path)
+    cohort_count = connection.execute(
+        'SELECT COUNT(*) FROM crypto_signal_candidate_cohorts'
+    ).fetchone()[0]
+    outcome_count = connection.execute(
+        'SELECT COUNT(*) FROM crypto_signal_candidate_outcomes'
+    ).fetchone()[0]
+    outcome_rows = connection.execute(
+        """
+        SELECT outcome_window, status
+        FROM crypto_signal_candidate_outcomes
+        ORDER BY outcome_window
+        """
+    ).fetchall()
+    connection.close()
+
+    assert first_save[0].cohort_id == second_save[0].cohort_id
+    assert cohort_count == 1
+    assert outcome_count == 3
+    assert outcome_rows == [
+        ('24h', 'pending'),
+        ('3d', 'pending'),
+        ('7d', 'pending'),
+    ]
+
+
+def test_get_unresolved_candidate_follow_up_entries_includes_due_but_not_future(
+    tmp_path,
+):
+    repository = CryptoSignalRepository(
+        db_path=str(tmp_path / 'crypto_signal.sqlite3')
+    )
+    signal_time = datetime.datetime(
+        2026,
+        5,
+        1,
+        8,
+        0,
+        tzinfo=datetime.timezone.utc,
+    )
+    repository.save_candidate_cohorts_from_view(
+        _build_digest_view(_build_snapshot_at(signal_time))
+    )
+
+    before_due = repository.get_unresolved_candidate_follow_up_entries(
+        runtime_mode='prod',
+        current_timestamp_utc=signal_time + datetime.timedelta(hours=12),
+    )
+    after_due = repository.get_unresolved_candidate_follow_up_entries(
+        runtime_mode='prod',
+        current_timestamp_utc=signal_time + datetime.timedelta(days=1),
+    )
+
+    assert before_due == []
+    assert after_due == [('SOL', 5426)]
+
+
+def test_resolve_due_candidate_outcomes_calculates_forward_and_relative_returns(
+    tmp_path,
+):
+    repository = CryptoSignalRepository(
+        db_path=str(tmp_path / 'crypto_signal.sqlite3')
+    )
+    signal_time = datetime.datetime(
+        2026,
+        5,
+        1,
+        8,
+        0,
+        tzinfo=datetime.timezone.utc,
+    )
+    repository.save_snapshot(
+        _build_snapshot_at(
+            signal_time,
+            sol_price_usd=100.0,
+            btc_price_usd=100_000.0,
+            eth_price_usd=4_000.0,
+        )
+    )
+    repository.save_candidate_cohorts_from_view(
+        _build_digest_view(repository.get_latest_snapshot())
+    )
+    repository.save_snapshot(
+        _build_snapshot_at(
+            signal_time + datetime.timedelta(days=1),
+            sol_price_usd=112.0,
+            btc_price_usd=104_000.0,
+            eth_price_usd=4_200.0,
+        )
+    )
+
+    outcomes = repository.resolve_due_candidate_outcomes(
+        runtime_mode='prod',
+        current_timestamp_utc=signal_time + datetime.timedelta(days=1),
+    )
+
+    assert len(outcomes) == 1
+    assert outcomes[0].outcome_window == '24h'
+    assert outcomes[0].status == 'resolved'
+    assert outcomes[0].absolute_return_pct == 12.0
+    assert outcomes[0].btc_relative_return_pct == 8.0
+    assert outcomes[0].eth_relative_return_pct == 7.0
+    assert repository.get_unresolved_candidate_follow_up_entries(
+        runtime_mode='prod',
+        current_timestamp_utc=signal_time + datetime.timedelta(days=1),
+    ) == []
+
+
+def test_resolve_due_candidate_outcomes_marks_missing_follow_up_data(tmp_path):
+    repository = CryptoSignalRepository(
+        db_path=str(tmp_path / 'crypto_signal.sqlite3')
+    )
+    signal_time = datetime.datetime(
+        2026,
+        5,
+        1,
+        8,
+        0,
+        tzinfo=datetime.timezone.utc,
+    )
+    repository.save_snapshot(_build_snapshot_at(signal_time))
+    repository.save_candidate_cohorts_from_view(
+        _build_digest_view(repository.get_latest_snapshot())
+    )
+    repository.save_snapshot(
+        _build_snapshot_at(
+            signal_time + datetime.timedelta(days=1),
+            sol_price_usd=None,
+            btc_price_usd=104_000.0,
+            eth_price_usd=4_200.0,
+        )
+    )
+
+    outcomes = repository.resolve_due_candidate_outcomes(
+        runtime_mode='prod',
+        current_timestamp_utc=signal_time + datetime.timedelta(days=1),
+    )
+
+    assert len(outcomes) == 1
+    assert outcomes[0].status == 'missing'
+    assert outcomes[0].missing_reason == 'missing_candidate_follow_up_price'
+
+
+def test_resolve_due_candidate_outcomes_marks_stale_follow_up_run_missing(tmp_path):
+    repository = CryptoSignalRepository(
+        db_path=str(tmp_path / 'crypto_signal.sqlite3')
+    )
+    signal_time = datetime.datetime(
+        2026,
+        5,
+        1,
+        8,
+        0,
+        tzinfo=datetime.timezone.utc,
+    )
+    repository.save_snapshot(_build_snapshot_at(signal_time))
+    repository.save_candidate_cohorts_from_view(
+        _build_digest_view(repository.get_latest_snapshot())
+    )
+    repository.save_snapshot(
+        _build_snapshot_at(
+            signal_time + datetime.timedelta(days=3),
+            sol_price_usd=112.0,
+            btc_price_usd=104_000.0,
+            eth_price_usd=4_200.0,
+        )
+    )
+
+    outcomes = repository.resolve_due_candidate_outcomes(
+        runtime_mode='prod',
+        current_timestamp_utc=signal_time + datetime.timedelta(days=3),
+    )
+
+    stale_24h_outcomes = [
+        outcome for outcome in outcomes if outcome.outcome_window == '24h'
+    ]
+    assert len(stale_24h_outcomes) == 1
+    assert stale_24h_outcomes[0].status == 'missing'
+    assert stale_24h_outcomes[0].missing_reason == 'stale_follow_up_run'
 
 
 def test_get_coin_observation_counts_since_does_not_create_missing_db(tmp_path):

--- a/tests/unit/service/crypto_signal/repository_test.py
+++ b/tests/unit/service/crypto_signal/repository_test.py
@@ -1,5 +1,6 @@
 import datetime
 import sqlite3
+from dataclasses import replace
 
 from src.service.crypto_signal.models import (
     CryptoSignalCandidate,
@@ -350,6 +351,92 @@ def test_save_candidate_cohorts_from_view_is_idempotent(tmp_path):
         ('3d', 'pending'),
         ('7d', 'pending'),
     ]
+
+
+def test_save_candidate_cohorts_from_view_keeps_original_frozen_facts_on_retry(tmp_path):
+    db_path = tmp_path / 'crypto_signal.sqlite3'
+    repository = CryptoSignalRepository(db_path=str(db_path))
+    snapshot = _build_snapshot_at(
+        datetime.datetime(2026, 5, 1, 8, 0, tzinfo=datetime.timezone.utc)
+    )
+    view = _build_digest_view(snapshot)
+    changed_view = _build_digest_view(snapshot)
+    changed_view.strong_candidates = [
+        replace(
+            changed_view.strong_candidates[0],
+            latest_price_usd=250.0,
+            score=9,
+            reason_tags=('changed-after-retry',),
+        )
+    ]
+    changed_view.market_regime_reason = 'changed regime after retry'
+
+    repository.save_candidate_cohorts_from_view(view)
+    repository.save_candidate_cohorts_from_view(changed_view)
+
+    connection = sqlite3.connect(db_path)
+    row = connection.execute(
+        """
+        SELECT baseline_price_usd, score, reason_tags_json, market_regime_reason
+        FROM crypto_signal_candidate_cohorts
+        """
+    ).fetchone()
+    connection.close()
+
+    assert row == (
+        100.0,
+        4,
+        '["price-persistence","volume-confirmation"]',
+        'OI +2.4%, avg funding -0.0028%',
+    )
+
+
+def test_save_candidate_cohorts_from_view_skips_stale_watchlist_baseline(tmp_path):
+    db_path = tmp_path / 'crypto_signal.sqlite3'
+    repository = CryptoSignalRepository(db_path=str(db_path))
+    latest_snapshot = _build_snapshot_at(
+        datetime.datetime(2026, 5, 1, 8, 0, tzinfo=datetime.timezone.utc),
+        sol_price_usd=None,
+    )
+    view = _build_digest_view(latest_snapshot)
+    view.strong_candidates = []
+    view.watchlist_candidates = [
+        CryptoSignalCandidate(
+            coin_id=5426,
+            symbol='SOL',
+            name='Solana',
+            latest_price_usd=100.0,
+            latest_volume_24h=4_820_000_000,
+            latest_price_change_24h=11.4,
+            window_price_change_pct=22.8,
+            latest_volume_change_pct_24h=27.1,
+            latest_context_tags=('watchlist',),
+            score=4,
+            price_persistence_score=2,
+            volume_confirmation_score=1,
+            attention_persistence_score=1,
+            breadth_alignment_score=0,
+            observation_count=7,
+            reason_tags=('price-persistence', 'volume-confirmation'),
+            flags=(),
+            is_watchlist=True,
+        )
+    ]
+
+    saved = repository.save_candidate_cohorts_from_view(view)
+
+    connection = sqlite3.connect(db_path)
+    cohort_count = connection.execute(
+        'SELECT COUNT(*) FROM crypto_signal_candidate_cohorts'
+    ).fetchone()[0]
+    outcome_count = connection.execute(
+        'SELECT COUNT(*) FROM crypto_signal_candidate_outcomes'
+    ).fetchone()[0]
+    connection.close()
+
+    assert saved == []
+    assert cohort_count == 0
+    assert outcome_count == 0
 
 
 def test_get_unresolved_candidate_follow_up_entries_includes_due_but_not_future(

--- a/tests/unit/service/crypto_signal/scorer_test.py
+++ b/tests/unit/service/crypto_signal/scorer_test.py
@@ -1,6 +1,7 @@
 import datetime
 
 from src.service.crypto_signal.models import (
+    CALIBRATION_FOLLOW_UP_CONTEXT_TAG,
     CryptoSignalCoinSnapshot,
     CryptoSignalRunRecord,
     CryptoSignalSnapshot,
@@ -288,3 +289,92 @@ def test_build_digest_view_filters_dynamic_candidates_below_operator_tradability
     )
 
     assert view.strong_candidates == []
+
+
+def test_build_digest_view_excludes_calibration_follow_up_only_candidate_from_ranking():
+    earlier_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 21, 8, 45, tzinfo=datetime.timezone.utc),
+        price_change_24h=12.0,
+        volume_change_pct_24h=35.0,
+        context_tags=('spotlight_trending', 'spotlight_gainer'),
+        coin_id=5690,
+        symbol='RENDER',
+        name='Render',
+        is_watchlist=False,
+        price_usd=8.12,
+        volume_24h=286_000_000,
+    )
+    latest_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 22, 8, 45, tzinfo=datetime.timezone.utc),
+        price_change_24h=18.0,
+        volume_change_pct_24h=45.0,
+        context_tags=(
+            'spotlight_trending',
+            'spotlight_gainer',
+            'sector_leader_strongest',
+            CALIBRATION_FOLLOW_UP_CONTEXT_TAG,
+        ),
+        coin_id=5690,
+        symbol='RENDER',
+        name='Render',
+        is_watchlist=False,
+        price_usd=8.12,
+        volume_24h=286_000_000,
+    )
+
+    view = build_digest_view(
+        latest_snapshot=latest_snapshot,
+        history=[earlier_snapshot, latest_snapshot],
+        watchlist_coin_ids=set(),
+        window_label='7d',
+        tracked_universe_coin_ids=set(),
+        limit=3,
+        min_dynamic_price_usd=1.0,
+        min_dynamic_volume_24h=50_000_000.0,
+    )
+
+    assert view.strong_candidates == []
+
+
+def test_build_digest_view_keeps_current_dynamic_candidate_without_follow_up_tag():
+    earlier_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 21, 8, 45, tzinfo=datetime.timezone.utc),
+        price_change_24h=12.0,
+        volume_change_pct_24h=35.0,
+        context_tags=('spotlight_trending', 'spotlight_gainer'),
+        coin_id=5690,
+        symbol='RENDER',
+        name='Render',
+        is_watchlist=False,
+        price_usd=7.8,
+        volume_24h=286_000_000,
+    )
+    latest_snapshot = _build_snapshot(
+        datetime.datetime(2026, 4, 22, 8, 45, tzinfo=datetime.timezone.utc),
+        price_change_24h=18.0,
+        volume_change_pct_24h=45.0,
+        context_tags=(
+            'spotlight_trending',
+            'spotlight_gainer',
+            'sector_leader_strongest',
+        ),
+        coin_id=5690,
+        symbol='RENDER',
+        name='Render',
+        is_watchlist=False,
+        price_usd=8.12,
+        volume_24h=286_000_000,
+    )
+
+    view = build_digest_view(
+        latest_snapshot=latest_snapshot,
+        history=[earlier_snapshot, latest_snapshot],
+        watchlist_coin_ids=set(),
+        window_label='7d',
+        tracked_universe_coin_ids=set(),
+        limit=3,
+        min_dynamic_price_usd=1.0,
+        min_dynamic_volume_24h=50_000_000.0,
+    )
+
+    assert [candidate.symbol for candidate in view.strong_candidates] == ['RENDER']


### PR DESCRIPTION
## Summary
- Add Phase 3A1 calibration cohort and outcome storage workflow
- Document the crypto signal data flow, cohort/outcome tables, and follow-up loop

## Validation
- Backend focused crypto signal suite: 57 passed, 1 existing pytz warning
- Backend ruff on changed files passed
- README diff check before commit